### PR TITLE
Add users table migration

### DIFF
--- a/bean/internal/driver/migration/001_add_uuid_extension.sql
+++ b/bean/internal/driver/migration/001_add_uuid_extension.sql
@@ -1,0 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+---- create above / drop below ----
+
+DROP EXTENSION IF EXISTS "uuid-ossp";

--- a/bean/internal/driver/migration/002_add_update_updated_at_col_func.sql
+++ b/bean/internal/driver/migration/002_add_update_updated_at_col_func.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION update_updated_at_col()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+---- create above / drop below ----
+
+DROP FUNCTION IF EXISTS update_updated_at_col() CASCADE;

--- a/bean/internal/driver/migration/003_add_users_table.sql
+++ b/bean/internal/driver/migration/003_add_users_table.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+  email VARCHAR(255) UNIQUE NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX users_id_idx ON users (id);
+CREATE INDEX users_email_idx ON users (email);
+
+CREATE TRIGGER update_users_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE PROCEDURE update_updated_at_col();
+
+---- create above / drop below ----
+
+DROP TRIGGER IF EXISTS update_users_updated_at ON users;
+
+DROP INDEX IF EXISTS users_id_idx;
+DROP INDEX IF EXISTS users_email_idx;
+
+DROP TABLE IF EXISTS users;


### PR DESCRIPTION
Users table with id, email, created_at, updated_at

Adds uuid extension for uuid 4 generation

Adds function to automatically update updated_at column

Testing instructions:
1. `dc up postgres -d`
2. `dc run --rm bean tern migrate`
3. `dc exec postgres psql -U postgres`
4. `\c bean_test`
5. `insert into users (email) values ('test-email-1') returning *;`
6. `update users set email = 'test-email-2' where email = 'test-email-1' returning *;`
7. Ensure the `updated_at` value is updated