### PR TITLE
Add tokens table migration

### DIFF
--- a/bean/internal/driver/migration/004_add_tokens_table.sql
+++ b/bean/internal/driver/migration/004_add_tokens_table.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS tokens (
+  id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+  email VARCHAR(255) UNIQUE NOT NULL,
+  hashed_token VARCHAR(60) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '10 minutes'
+);
+
+CREATE INDEX tokens_id_idx ON tokens (id);
+CREATE INDEX tokens_email_idx ON tokens (email);
+
+CREATE OR REPLACE FUNCTION overwrite_token_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created_at = CURRENT_TIMESTAMP;
+    NEW.expires_at = CURRENT_TIMESTAMP + INTERVAL '10 minutes';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER overwrite_token
+BEFORE UPDATE ON tokens
+FOR EACH ROW
+EXECUTE PROCEDURE overwrite_token_timestamp();
+
+---- create above / drop below ----
+
+DROP TRIGGER IF EXISTS overwrite_token ON tokens;
+
+DROP FUNCTION IF EXISTS overwrite_token_timestamp() CASCADE;
+
+DROP INDEX IF EXISTS tokens_id_idx;
+DROP INDEX IF EXISTS tokens_email_idx;
+
+DROP TABLE IF EXISTS tokens;


### PR DESCRIPTION
Tokens table with id, email, hashed_token, created_at, expires_at

When a row is updated due to email conflict, the created_at and expires_at get updated

Testing instructions:
1. `dc up postgres -d`
2. `dc run --rm bean tern migrate`
3. `dc exec postgres psql -U postgres`
4. `\c bean_test`
5. `insert into tokens (email, hashed_token) values ('test-email-1', 'hashed-token-1') on conflict (email) do update set hashed_token = 'hashed-token-2' returning *;`
6. Repeat step 5
7. Ensure the `created_at` and `expires_at` cols are updated
8. `dc run --rm bean tern migrate --destination -1`
9. Ensure no errors