### PR TITLE
Fix postgres package name

### DIFF
--- a/bean/internal/driver/postgres/dsn.go
+++ b/bean/internal/driver/postgres/dsn.go
@@ -1,4 +1,4 @@
-package database
+package postgres
 
 import (
 	"fmt"

--- a/bean/internal/driver/postgres/dsn_test.go
+++ b/bean/internal/driver/postgres/dsn_test.go
@@ -1,4 +1,4 @@
-package database
+package postgres
 
 import (
 	"testing"

--- a/bean/internal/driver/postgres/postgres.go
+++ b/bean/internal/driver/postgres/postgres.go
@@ -1,4 +1,4 @@
-package database
+package postgres
 
 import (
 	"context"

--- a/bean/internal/driver/postgres/postgres_test.go
+++ b/bean/internal/driver/postgres/postgres_test.go
@@ -1,4 +1,4 @@
-package database
+package postgres
 
 import (
 	"os"
@@ -17,7 +17,7 @@ func DBTest(t *testing.T) *DB {
 	}
 
 	db, err := New(&DSNBuilder{
-		Host:     "localhost",
+		Host:     "postgres",
 		Port:     "5432",
 		Name:     "bean_test",
 		Username: "postgres",


### PR DESCRIPTION
Fixes postgres package name and running go tests from inside container

Testing instructions:
1. `dc up postgres -d`
2. `dc run --rm -e INTEGRATION_DB=1 bean go test ./... -v`
3. Ensure `TestDB` isn't skipped and passes