### PR TITLE
Add persistance to postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     volumes:
       - ./bean:/go/src/bean
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   postgres:
     <<: *common
@@ -30,6 +31,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
 
 volumes:
   postgres-data:


### PR DESCRIPTION
Maintains data after stopping the container and bringing it back up

Also removes need to `dc up postgres -d` before `dc run bean`

Testing instructions:
1. `dc down --remove-orphans` 
2. `dc run --rm bean tern migrate`
4. `dc down --remove-orphans` 
5. `dc run --rm bean tern migrate`
6. No new migrations should run