### PR TITLE
Fix token and user datasource tests

### DIFF
--- a/bean/internal/driver/datasource/token/token_test.go
+++ b/bean/internal/driver/datasource/token/token_test.go
@@ -82,8 +82,7 @@ func findUnexpired(t *testing.T, ds usecase.LoginTokenDataSource) {
 			t.Fatalf("failed to create token: %s", err)
 		}
 
-		_, err = ds.FindUnexpired(token.ID)
-		if err != nil {
+		if _, err = ds.FindUnexpired(token.ID); err != nil {
 			t.Fatalf("failed to find token: %s", err)
 		}
 
@@ -100,8 +99,7 @@ func findUnexpired(t *testing.T, ds usecase.LoginTokenDataSource) {
 	})
 
 	t.Run("nonexistent_token", func(t *testing.T) {
-		_, err := ds.FindUnexpired("nonexistent")
-		if err == nil {
+		if _, err := ds.FindUnexpired("nonexistent"); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
@@ -118,15 +116,13 @@ func delete(t *testing.T, ds usecase.LoginTokenDataSource) {
 			t.Fatalf("failed to delete token: %s", err)
 		}
 
-		_, err = ds.FindUnexpired(token.ID)
-		if err == nil {
+		if _, err = ds.FindUnexpired(token.ID); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 
 	t.Run("nonexistent_token", func(t *testing.T) {
-		err := ds.Delete("nonexistent")
-		if err == nil {
+		if err := ds.Delete("nonexistent"); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})

--- a/bean/internal/driver/datasource/user/user_test.go
+++ b/bean/internal/driver/datasource/user/user_test.go
@@ -48,8 +48,7 @@ func create(t *testing.T, ds usecase.UserDataSource) {
 			t.Error("expected creation time, got zero time")
 		}
 
-		err = ds.Delete(user.ID)
-		if err != nil {
+		if err = ds.Delete(user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
@@ -60,13 +59,11 @@ func create(t *testing.T, ds usecase.UserDataSource) {
 			t.Fatalf("failed to create user: %s", err)
 		}
 
-		_, err = ds.Create("action-reject")
-		if err == nil {
+		if _, err = ds.Create("action-reject"); err == nil {
 			t.Errorf("expected error, got nil")
 		}
 
-		err = ds.Delete(user.ID)
-		if err != nil {
+		if err = ds.Delete(user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
@@ -88,15 +85,13 @@ func findById(t *testing.T, ds usecase.UserDataSource) {
 			t.Errorf("expected same token ID, got: %s", found.ID)
 		}
 
-		err = ds.Delete(user.ID)
-		if err != nil {
+		if err = ds.Delete(user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
 
 	t.Run("nonexistent_user", func(t *testing.T) {
-		_, err := ds.FindById("nonexistent")
-		if err == nil {
+		if _, err := ds.FindById("nonexistent"); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
@@ -118,15 +113,13 @@ func findByEmail(t *testing.T, ds usecase.UserDataSource) {
 			t.Errorf("expected same token ID, got: %s", found.ID)
 		}
 
-		err = ds.Delete(user.ID)
-		if err != nil {
+		if err = ds.Delete(user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
 
 	t.Run("nonexistent_user", func(t *testing.T) {
-		_, err := ds.FindByEmail("nonexistent")
-		if err == nil {
+		if _, err := ds.FindByEmail("nonexistent"); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
@@ -139,20 +132,17 @@ func delete(t *testing.T, ds usecase.UserDataSource) {
 			t.Fatalf("failed to create user: %s", err)
 		}
 
-		err = ds.Delete(user.ID)
-		if err != nil {
+		if err = ds.Delete(user.ID); err != nil {
 			t.Fatalf("failed to delete user: %s", err)
 		}
 
-		_, err = ds.FindById(user.ID)
-		if err == nil {
+		if _, err = ds.FindById(user.ID); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 
 	t.Run("nonexistent_user", func(t *testing.T) {
-		err := ds.Delete("nonexistent")
-		if err == nil {
+		if err := ds.Delete("nonexistent"); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})


### PR DESCRIPTION
User data source wasn't cleaning up `action-new`

Login tokens wasn't checking for nonexistent tokens

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. `dc exec -e INTEGRATION_DB=1 bean go test ./... -v`
4. Ensure all tests aren't skipped and pass
5. `dc exec postgres psql -U postgres`
6. `\c bean_test`
7. `select * from users;`
8. `select * from login_tokens;`
9. Ensure there are is non-seeded rows