### PR TITLE
Fix interfaces usecase package

### DIFF
--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -6,7 +6,7 @@ import (
 
 	"harvest/bean/internal/entity"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres"
 )
@@ -15,7 +15,7 @@ type dataSource struct {
 	db *postgres.DB
 }
 
-func New(db *postgres.DB) usecase.PaymentMethodDataSource {
+func New(db *postgres.DB) interfaces.PaymentMethodDataSource {
 	return &dataSource{db}
 }
 

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
@@ -3,7 +3,7 @@ package paymentmethod
 import (
 	"testing"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
 )
@@ -36,7 +36,7 @@ func TestDataSouce(t *testing.T) {
 	})
 }
 
-func create(t *testing.T, ds usecase.PaymentMethodDataSource) {
+func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	method, err := ds.Create(userWithMethodsId, "action-create", "1234", "brand", 12, 2024)
 	if err != nil {
 		t.Fatalf("failed to create payment method: %s", err)
@@ -75,7 +75,7 @@ func create(t *testing.T, ds usecase.PaymentMethodDataSource) {
 	}
 }
 
-func findById(t *testing.T, ds usecase.PaymentMethodDataSource) {
+func findById(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	t.Run("existing_payment_method", func(t *testing.T) {
 		if _, err := ds.FindById(methodId); err != nil {
 			t.Fatalf("failed to find payment method by id: %s", err)
@@ -89,7 +89,7 @@ func findById(t *testing.T, ds usecase.PaymentMethodDataSource) {
 	})
 }
 
-func findByUserId(t *testing.T, ds usecase.PaymentMethodDataSource) {
+func findByUserId(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	t.Run("has_payment_methods", func(t *testing.T) {
 		methods, err := ds.FindByUserId(userWithMethodsId)
 		if err != nil {
@@ -119,7 +119,7 @@ func findByUserId(t *testing.T, ds usecase.PaymentMethodDataSource) {
 	})
 }
 
-func delete(t *testing.T, ds usecase.PaymentMethodDataSource) {
+func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	t.Run("existing_payment_method", func(t *testing.T) {
 		method, err := ds.Create(userWithMethodsId, "action-delete", "1234", "brand", 12, 2024)
 		if err != nil {

--- a/bean/internal/driver/datasource/subscription/subscription.go
+++ b/bean/internal/driver/datasource/subscription/subscription.go
@@ -6,7 +6,7 @@ import (
 
 	"harvest/bean/internal/entity"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres"
 )
@@ -15,7 +15,7 @@ type dataSource struct {
 	db *postgres.DB
 }
 
-func New(db *postgres.DB) usecase.SubscriptionDataSource {
+func New(db *postgres.DB) interfaces.SubscriptionDataSource {
 	return &dataSource{
 		db: db,
 	}

--- a/bean/internal/driver/datasource/subscription/subscription_test.go
+++ b/bean/internal/driver/datasource/subscription/subscription_test.go
@@ -3,7 +3,7 @@ package subscription
 import (
 	"testing"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
 )
@@ -38,7 +38,7 @@ func TestDataSouce(t *testing.T) {
 	})
 }
 
-func create(t *testing.T, ds usecase.SubscriptionDataSource) {
+func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	sub, err := ds.Create(userWithSubsId, methodId, "action-create", "bean", 1000, 1, "month")
 	if err != nil {
 		t.Fatalf("failed to create subscription: %s", err)
@@ -81,7 +81,7 @@ func create(t *testing.T, ds usecase.SubscriptionDataSource) {
 	}
 }
 
-func findById(t *testing.T, ds usecase.SubscriptionDataSource) {
+func findById(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("existing_subscription", func(t *testing.T) {
 		if _, err := ds.FindById(subId); err != nil {
 			t.Fatalf("failed to find subscription by id: %s", err)
@@ -95,7 +95,7 @@ func findById(t *testing.T, ds usecase.SubscriptionDataSource) {
 	})
 }
 
-func findByUserId(t *testing.T, ds usecase.SubscriptionDataSource) {
+func findByUserId(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("has_subscriptions", func(t *testing.T) {
 		subs, err := ds.FindByUserId(userWithSubsId)
 		if err != nil {
@@ -125,7 +125,7 @@ func findByUserId(t *testing.T, ds usecase.SubscriptionDataSource) {
 	})
 }
 
-func delete(t *testing.T, ds usecase.SubscriptionDataSource) {
+func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("existing_subscription", func(t *testing.T) {
 		sub, err := ds.Create(userWithSubsId, methodId, "action-delete", "bean", 1000, 1, "month")
 		if err != nil {

--- a/bean/internal/driver/datasource/token/token.go
+++ b/bean/internal/driver/datasource/token/token.go
@@ -6,7 +6,7 @@ import (
 
 	"harvest/bean/internal/entity"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres"
 )
@@ -15,7 +15,7 @@ type dataSource struct {
 	db *postgres.DB
 }
 
-func New(db *postgres.DB) usecase.LoginTokenDataSource {
+func New(db *postgres.DB) interfaces.LoginTokenDataSource {
 	return &dataSource{
 		db: db,
 	}

--- a/bean/internal/driver/datasource/token/token_test.go
+++ b/bean/internal/driver/datasource/token/token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
 )
@@ -30,7 +30,7 @@ func TestDataSource(t *testing.T) {
 	})
 }
 
-func create(t *testing.T, ds usecase.LoginTokenDataSource) {
+func create(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	t.Run("new_token", func(t *testing.T) {
 		token, err := ds.Create("action-create", "hashed-token")
 		if err != nil {
@@ -79,7 +79,7 @@ func create(t *testing.T, ds usecase.LoginTokenDataSource) {
 	})
 }
 
-func findUnexpired(t *testing.T, ds usecase.LoginTokenDataSource) {
+func findUnexpired(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	t.Run("valid_token", func(t *testing.T) {
 		token, err := ds.Create("action-find", "hashed-token")
 		if err != nil {
@@ -109,7 +109,7 @@ func findUnexpired(t *testing.T, ds usecase.LoginTokenDataSource) {
 	})
 }
 
-func delete(t *testing.T, ds usecase.LoginTokenDataSource) {
+func delete(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	t.Run("existing_token", func(t *testing.T) {
 		token, err := ds.Create("action-delete", "hashed-token")
 		if err != nil {

--- a/bean/internal/driver/datasource/user/user.go
+++ b/bean/internal/driver/datasource/user/user.go
@@ -6,7 +6,7 @@ import (
 
 	"harvest/bean/internal/entity"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres"
 )
@@ -15,7 +15,7 @@ type dataSource struct {
 	db *postgres.DB
 }
 
-func New(db *postgres.DB) usecase.UserDataSource {
+func New(db *postgres.DB) interfaces.UserDataSource {
 	return &dataSource{
 		db: db,
 	}

--- a/bean/internal/driver/datasource/user/user_test.go
+++ b/bean/internal/driver/datasource/user/user_test.go
@@ -3,7 +3,7 @@ package user
 import (
 	"testing"
 
-	"harvest/bean/internal/usecase"
+	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
 )
@@ -33,7 +33,7 @@ func TestDataSource(t *testing.T) {
 	})
 }
 
-func create(t *testing.T, ds usecase.UserDataSource) {
+func create(t *testing.T, ds interfaces.UserDataSource) {
 	t.Run("new_user", func(t *testing.T) {
 		user, err := ds.Create("action-create")
 		if err != nil {
@@ -73,7 +73,7 @@ func create(t *testing.T, ds usecase.UserDataSource) {
 	})
 }
 
-func findById(t *testing.T, ds usecase.UserDataSource) {
+func findById(t *testing.T, ds interfaces.UserDataSource) {
 	t.Run("existing_user", func(t *testing.T) {
 		if _, err := ds.FindById(userId); err != nil {
 			t.Fatalf("failed to find user by id: %s", err)
@@ -87,7 +87,7 @@ func findById(t *testing.T, ds usecase.UserDataSource) {
 	})
 }
 
-func findByEmail(t *testing.T, ds usecase.UserDataSource) {
+func findByEmail(t *testing.T, ds interfaces.UserDataSource) {
 	t.Run("existing_user", func(t *testing.T) {
 		if _, err := ds.FindByEmail("user-1"); err != nil {
 			t.Fatalf("failed to find user by email: %s", err)
@@ -101,7 +101,7 @@ func findByEmail(t *testing.T, ds usecase.UserDataSource) {
 	})
 }
 
-func delete(t *testing.T, ds usecase.UserDataSource) {
+func delete(t *testing.T, ds interfaces.UserDataSource) {
 	t.Run("existing_user", func(t *testing.T) {
 		user, err := ds.Create("action-delete")
 		if err != nil {

--- a/bean/internal/usecases/interfaces/interfaces.go
+++ b/bean/internal/usecases/interfaces/interfaces.go
@@ -1,4 +1,4 @@
-package usecase
+package interfaces
 
 import (
 	"harvest/bean/internal/entity"

--- a/bean/internal/usecases/interfaces/interfaces_test.go
+++ b/bean/internal/usecases/interfaces/interfaces_test.go
@@ -1,3 +1,3 @@
-package usecase
+package interfaces
 
 // nothing to test yet


### PR DESCRIPTION
Moves interfaces into their own package under usecases

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. `dc exec -e INTEGRATIONS_DB=1 bean go test ./... -v`