### PR TITLE
Fix invalid nonexistent uuid

### DIFF
--- a/bean/internal/driver/datasource/subscription/subscription_test.go
+++ b/bean/internal/driver/datasource/subscription/subscription_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 var (
-	userWithSubsId   = "00000000-0000-0000-0002-000000000001"
-	userWithNoSubsId = "00000000-0000-0000-0002-000000000002"
+	userWithSubsID   = "00000000-0000-0000-0002-000000000001"
+	userWithNoSubsID = "00000000-0000-0000-0002-000000000002"
 
-	methodId = "00000000-0000-0000-0001-000000000001"
+	methodID = "00000000-0000-0000-0001-000000000001"
 
-	subId = "00000000-0000-0000-0000-000000000001"
+	subID         = "00000000-0000-0000-0000-000000000001"
+	nonexistentID = "11111111-1111-1111-1111-111111111111"
 )
 
 func TestDataSouce(t *testing.T) {
@@ -39,7 +40,7 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
-	sub, err := ds.Create(userWithSubsId, methodId, "action-create", "bean", 1000, 1, "month")
+	sub, err := ds.Create(userWithSubsID, methodID, "action-create", "bean", 1000, 1, "month")
 	if err != nil {
 		t.Fatalf("failed to create subscription: %s", err)
 	}
@@ -48,12 +49,12 @@ func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
 		t.Error("expected subscription ID, got empty string")
 	}
 
-	if sub.UserID != userWithSubsId {
-		t.Errorf("expected user ID: %s, got: %s", userWithSubsId, sub.UserID)
+	if sub.UserID != userWithSubsID {
+		t.Errorf("expected user ID: %s, got: %s", userWithSubsID, sub.UserID)
 	}
 
-	if sub.PaymentMethodID != methodId {
-		t.Errorf("expected payment method ID: %s, got: %s", methodId, sub.PaymentMethodID)
+	if sub.PaymentMethodID != methodID {
+		t.Errorf("expected payment method ID: %s, got: %s", methodID, sub.PaymentMethodID)
 	}
 
 	if sub.Label != "action-create" {
@@ -83,13 +84,13 @@ func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
 
 func findById(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("existing_subscription", func(t *testing.T) {
-		if _, err := ds.FindById(subId); err != nil {
+		if _, err := ds.FindById(subID); err != nil {
 			t.Fatalf("failed to find subscription by id: %s", err)
 		}
 	})
 
 	t.Run("nonexistent_subscription", func(t *testing.T) {
-		if _, err := ds.FindById("nonexistent"); err == nil {
+		if _, err := ds.FindById(nonexistentID); err == nil {
 			t.Fatalf("expected error, got nil")
 		}
 	})
@@ -97,7 +98,7 @@ func findById(t *testing.T, ds interfaces.SubscriptionDataSource) {
 
 func findByUserId(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("has_subscriptions", func(t *testing.T) {
-		subs, err := ds.FindByUserId(userWithSubsId)
+		subs, err := ds.FindByUserId(userWithSubsID)
 		if err != nil {
 			t.Fatalf("failed to find subscriptions by user id: %s", err)
 		}
@@ -107,14 +108,14 @@ func findByUserId(t *testing.T, ds interfaces.SubscriptionDataSource) {
 		}
 
 		for _, sub := range subs {
-			if sub.UserID != userWithSubsId {
-				t.Errorf("expected user ID: %s, got: %s", userWithSubsId, sub.UserID)
+			if sub.UserID != userWithSubsID {
+				t.Errorf("expected user ID: %s, got: %s", userWithSubsID, sub.UserID)
 			}
 		}
 	})
 
 	t.Run("no_subscriptions", func(t *testing.T) {
-		subs, err := ds.FindByUserId(userWithNoSubsId)
+		subs, err := ds.FindByUserId(userWithNoSubsID)
 		if err != nil {
 			t.Fatalf("failed to find subscriptions by user id: %s", err)
 		}
@@ -127,7 +128,7 @@ func findByUserId(t *testing.T, ds interfaces.SubscriptionDataSource) {
 
 func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("existing_subscription", func(t *testing.T) {
-		sub, err := ds.Create(userWithSubsId, methodId, "action-delete", "bean", 1000, 1, "month")
+		sub, err := ds.Create(userWithSubsID, methodID, "action-delete", "bean", 1000, 1, "month")
 		if err != nil {
 			t.Fatalf("failed to create subscription: %s", err)
 		}
@@ -142,8 +143,8 @@ func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	})
 
 	t.Run("nonexistent_subscription", func(t *testing.T) {
-		if err := ds.Delete("nonexistent"); err == nil {
-			t.Fatalf("expected error, got nil")
+		if err := ds.Delete(nonexistentID); err != nil {
+			t.Fatalf("failed to delete subscription: %s", err)
 		}
 	})
 }

--- a/bean/internal/driver/datasource/token/token_test.go
+++ b/bean/internal/driver/datasource/token/token_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	expiredId = "00000000-0000-0000-0000-000000000001"
+	expiredID     = "00000000-0000-0000-0000-000000000001"
+	nonexistentID = "11111111-1111-1111-1111-111111111111"
 )
 
 func TestDataSource(t *testing.T) {
@@ -96,14 +97,14 @@ func findUnexpired(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	})
 
 	t.Run("expired_token", func(t *testing.T) {
-		token, _ := ds.FindUnexpired(expiredId)
+		token, _ := ds.FindUnexpired(expiredID)
 		if token != nil && token.ExpiresAt.Before(time.Now()) {
 			t.Errorf("expected nil token, got: %v", token)
 		}
 	})
 
 	t.Run("nonexistent_token", func(t *testing.T) {
-		if _, err := ds.FindUnexpired("nonexistent"); err == nil {
+		if _, err := ds.FindUnexpired(nonexistentID); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
@@ -126,8 +127,8 @@ func delete(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	})
 
 	t.Run("nonexistent_token", func(t *testing.T) {
-		if err := ds.Delete("nonexistent"); err == nil {
-			t.Error("expected error, got nil")
+		if err := ds.Delete(nonexistentID); err != nil {
+			t.Fatalf("failed to delete token: %s", err)
 		}
 	})
 }

--- a/bean/internal/driver/datasource/user/user_test.go
+++ b/bean/internal/driver/datasource/user/user_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	userId = "00000000-0000-0000-0000-000000000001"
+	userID        = "00000000-0000-0000-0000-000000000001"
+	nonexistentID = "11111111-1111-1111-1111-111111111111"
 )
 
 func TestDataSource(t *testing.T) {
@@ -75,13 +76,13 @@ func create(t *testing.T, ds interfaces.UserDataSource) {
 
 func findById(t *testing.T, ds interfaces.UserDataSource) {
 	t.Run("existing_user", func(t *testing.T) {
-		if _, err := ds.FindById(userId); err != nil {
+		if _, err := ds.FindById(userID); err != nil {
 			t.Fatalf("failed to find user by id: %s", err)
 		}
 	})
 
 	t.Run("nonexistent_user", func(t *testing.T) {
-		if _, err := ds.FindById("nonexistent"); err == nil {
+		if _, err := ds.FindById(nonexistentID); err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
@@ -118,8 +119,8 @@ func delete(t *testing.T, ds interfaces.UserDataSource) {
 	})
 
 	t.Run("nonexistent_user", func(t *testing.T) {
-		if err := ds.Delete("nonexistent"); err == nil {
-			t.Error("expected error, got nil")
+		if err := ds.Delete(nonexistentID); err != nil {
+			t.Fatalf("failed to delete user: %s", err)
 		}
 	})
 }


### PR DESCRIPTION
The tests were using `"nonexistent"` making the tests fail because of incorrect uuid

Switches to a valid uuid that is likely not to exist in the database
Works for now 🤷🏼 

Testing instructions:
1. `dc down --volumes`
2. `dc up --build bean`
3. `dc exec -e INTEGRATION_DB=1 bean go test ./... -v`
4. Ensure nothing is skipped and all pass
5. `dc exec postgres psql -U postgres bean_test -c 'select * from users;'`
6. `dc exec postgres psql -U postgres bean_test -c 'select * from login_tokens;'`
7. `dc exec postgres psql -U postgres bean_test -c 'select * from subscriptions;'`
8. Ensure there are no action rows in any table