### PR TITLE
Add passwordless usecase validation

### DIFF
--- a/bean/internal/usecases/passwordless/passwordless.go
+++ b/bean/internal/usecases/passwordless/passwordless.go
@@ -19,6 +19,10 @@ type UseCase struct {
 }
 
 func (u *UseCase) SendEmail(email string) error {
+	if err := validateEmail(email); err != nil {
+		return fmt.Errorf("failed to validate email: %w", err)
+	}
+
 	rand, err := uuid.NewRandom()
 	if err != nil {
 		return fmt.Errorf("failed to generate password: %w", err)

--- a/bean/internal/usecases/passwordless/validation.go
+++ b/bean/internal/usecases/passwordless/validation.go
@@ -1,0 +1,23 @@
+package passwordless
+
+import (
+	"fmt"
+	"net/mail"
+)
+
+func validateEmail(email string) error {
+	if len(email) < 3 {
+		return fmt.Errorf("email must be greater than 2 chars")
+	}
+
+	if len(email) > 255 {
+		return fmt.Errorf("email must be less than 255 chars")
+	}
+
+	_, err := mail.ParseAddress(email)
+	if err != nil {
+		return fmt.Errorf("email must be valid")
+	}
+
+	return nil
+}

--- a/bean/internal/usecases/passwordless/validation_test.go
+++ b/bean/internal/usecases/passwordless/validation_test.go
@@ -1,0 +1,41 @@
+package passwordless
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateEmail(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tests := []string{
+			"277@hey.com",
+			"bean@whatis277.com",
+			"nizar@whatis277.com",
+			"nizarmah@hotmail.com",
+			"nizar.mah99@gmail.com",
+		}
+
+		for _, test := range tests {
+			if err := validateEmail(test); err != nil {
+				t.Errorf("expected nil, got: %s", err)
+			}
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []string{
+			"a",
+			"aa",
+			strings.Repeat("a", 256),
+			"bean",
+			"bean@",
+			"@bean",
+		}
+
+		for _, test := range tests {
+			if err := validateEmail(test); err == nil {
+				t.Errorf("expected error, got nil: %s", test)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Validates the email before creating a token

Testing instructions:
1. `dc down --volumes`
2. `dc up --build bean`
3. `dc exec -e INTEGRATIONS_DB=1 bean go test ./... -v`
4. ...