### PR TITLE
Add paymentmethod brand consts

### DIFF
--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -25,7 +25,7 @@ func (ds *dataSource) Create(
 	userID string,
 	label string,
 	last4 string,
-	brand string,
+	brand entity.PaymentMethodBrand,
 	expMonth int,
 	expYear int,
 ) (*entity.PaymentMethod, error) {

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
@@ -3,6 +3,8 @@ package paymentmethod
 import (
 	"testing"
 
+	"harvest/bean/internal/entity"
+
 	"harvest/bean/internal/usecases/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
@@ -38,7 +40,7 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
-	method, err := ds.Create(userWithMethodsID, "action-create", "1234", "brand", 12, 2024)
+	method, err := ds.Create(userWithMethodsID, "action-create", "1234", entity.PaymentMethodBrandAmex, 12, 2024)
 	if err != nil {
 		t.Fatalf("failed to create payment method: %s", err)
 	}
@@ -59,8 +61,8 @@ func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 		t.Errorf("expected last4: %s, got: %s", "1234", method.Last4)
 	}
 
-	if method.Brand != "brand" {
-		t.Errorf("expected brand: %s, got: %s", "brand", method.Brand)
+	if method.Brand != entity.PaymentMethodBrandAmex {
+		t.Errorf("expected brand: %s, got: %s", entity.PaymentMethodBrandAmex, method.Brand)
 	}
 
 	if method.ExpMonth != 12 {
@@ -143,7 +145,7 @@ func findByUserID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 
 func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	t.Run("existing_payment_method", func(t *testing.T) {
-		method, err := ds.Create(userWithMethodsID, "action-delete", "1234", "brand", 12, 2024)
+		method, err := ds.Create(userWithMethodsID, "action-delete", "1234", entity.PaymentMethodBrandAmex, 12, 2024)
 		if err != nil {
 			t.Fatalf("failed to create payment method: %s", err)
 		}

--- a/bean/internal/entity/entity.go
+++ b/bean/internal/entity/entity.go
@@ -30,13 +30,21 @@ type Subscription struct {
 	UpdatedAt time.Time
 }
 
+type PaymentMethodBrand string
+
+const (
+	PaymentMethodBrandAmex       PaymentMethodBrand = "amex"
+	PaymentMethodBrandMastercard PaymentMethodBrand = "mastercard"
+	PaymentMethodBrandVisa       PaymentMethodBrand = "visa"
+)
+
 type PaymentMethod struct {
 	ID     string
 	UserID string
 
 	Label    string
 	Last4    string
-	Brand    string
+	Brand    PaymentMethodBrand
 	ExpMonth int
 	ExpYear  int
 

--- a/bean/internal/entity/entity_test.go
+++ b/bean/internal/entity/entity_test.go
@@ -1,3 +1,0 @@
-package entity
-
-// nothing to test yet

--- a/bean/internal/usecases/interfaces/interfaces.go
+++ b/bean/internal/usecases/interfaces/interfaces.go
@@ -28,7 +28,7 @@ type PaymentMethodDataSource interface {
 		userID string,
 		label string,
 		last4 string,
-		brand string,
+		brand entity.PaymentMethodBrand,
 		expMonth int,
 		expYear int,
 	) (*entity.PaymentMethod, error)

--- a/bean/internal/usecases/interfaces/interfaces_test.go
+++ b/bean/internal/usecases/interfaces/interfaces_test.go
@@ -1,3 +1,0 @@
-package interfaces
-
-// nothing to test yet

--- a/bean/internal/usecases/paymentmethod/paymentmethod.go
+++ b/bean/internal/usecases/paymentmethod/paymentmethod.go
@@ -16,7 +16,7 @@ func (u *UseCase) Create(
 	userID string,
 	label string,
 	last4 string,
-	brand string,
+	brand entity.PaymentMethodBrand,
 	expMonth int,
 	expYear int,
 ) (*entity.PaymentMethod, error) {

--- a/bean/internal/usecases/paymentmethod/validation.go
+++ b/bean/internal/usecases/paymentmethod/validation.go
@@ -3,6 +3,8 @@ package paymentmethod
 import (
 	"fmt"
 	"regexp"
+
+	"harvest/bean/internal/entity"
 )
 
 func validateLabel(label string) error {
@@ -26,12 +28,19 @@ func validateLast4(last4 string) error {
 	return nil
 }
 
-func validateBrand(brand string) error {
+func validateBrand(brand entity.PaymentMethodBrand) error {
 	switch brand {
-	case "visa", "mastercard", "amex":
+	case entity.PaymentMethodBrandAmex,
+		entity.PaymentMethodBrandMastercard,
+		entity.PaymentMethodBrandVisa:
 		return nil
 	default:
-		return fmt.Errorf("brand must be visa, mastercard, or amex")
+		return fmt.Errorf(
+			"brand must be: %s, %s, %s",
+			entity.PaymentMethodBrandAmex,
+			entity.PaymentMethodBrandMastercard,
+			entity.PaymentMethodBrandVisa,
+		)
 	}
 }
 

--- a/bean/internal/usecases/paymentmethod/validation_test.go
+++ b/bean/internal/usecases/paymentmethod/validation_test.go
@@ -3,6 +3,8 @@ package paymentmethod
 import (
 	"strings"
 	"testing"
+
+	"harvest/bean/internal/entity"
 )
 
 func TestValidateLabel(t *testing.T) {
@@ -41,7 +43,11 @@ func TestValidateLast4(t *testing.T) {
 
 func TestValidateBrand(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		tests := []string{"visa", "mastercard", "amex"}
+		tests := []entity.PaymentMethodBrand{
+			entity.PaymentMethodBrandAmex,
+			entity.PaymentMethodBrandMastercard,
+			entity.PaymentMethodBrandVisa,
+		}
 
 		for _, test := range tests {
 			if err := validateBrand(test); err != nil {

--- a/bean/internal/usecases/subscription/validation.go
+++ b/bean/internal/usecases/subscription/validation.go
@@ -46,6 +46,12 @@ func validatePeriod(period entity.SubscriptionPeriod) error {
 		entity.SubscriptionPeriodYearly:
 		return nil
 	default:
-		return fmt.Errorf("period must be day, week, month or year")
+		return fmt.Errorf(
+			"period must be: %s, %s, %s, %s",
+			entity.SubscriptionPeriodDaily,
+			entity.SubscriptionPeriodWeekly,
+			entity.SubscriptionPeriodMonthly,
+			entity.SubscriptionPeriodYearly,
+		)
 	}
 }

--- a/bean/internal/usecases/userdash/utils_test.go
+++ b/bean/internal/usecases/userdash/utils_test.go
@@ -71,8 +71,6 @@ func TestGetEstimatesFromYearly(t *testing.T) {
 	amount := 100000
 	estimates := getEstimatesFromYearly(amount)
 
-	t.Log(estimates)
-
 	if estimates.Daily != amount/365 {
 		t.Errorf("daily estimate should be %d, got %d", amount/365, estimates.Daily)
 	}


### PR DESCRIPTION
Payment method brand constants visa, mastercard, and amex

Removes userdash forgotten `t.Log`

Fixes subscription period validation error

Drops empty test files

Testing instructions:
1. `dc down --volumes`
2. `dc up --build bean`
3. `dc exec -e INTEGRATION=1 bean go test ./... -v`