### PR TITLE
Fix installing dependencies once

### DIFF
--- a/bean/Dockerfile
+++ b/bean/Dockerfile
@@ -10,8 +10,14 @@ COPY go.mod go.sum ./
 # copy bean code
 COPY bean/ ./bean/
 
-# get deps
+# get deps : go.mod
 RUN go mod download
+
+# get deps : tern (migration, seed)
+RUN go install github.com/jackc/tern/v2@latest
+
+# get deps : air (hot reload)
+RUN go install github.com/cosmtrek/air@latest
 
 # run boot script
 CMD ["bean/bin/boot.sh"]

--- a/bean/bin/boot.sh
+++ b/bean/bin/boot.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env sh
 
 function main() {
-  install_deps
-
   migrate
 
   seed
 
   run
-}
-
-function install_deps() {
-  # tern for migration and seed
-  go install github.com/jackc/tern/v2@latest
-
-  # air for live reload
-  go install github.com/cosmtrek/air@latest
 }
 
 function migrate() {


### PR DESCRIPTION
Installs `tern` and `air` once, instead of on every `dc up bean`

Moves installing deps from `bin/boot.sh` to `Dockerfile`

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. Ensure it installs tern and air
4. `dc down`
5. `dc up bean`
6. Ensure it doesn't install tern and air again 