### PR TITLE
pear: Add always serve index to nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 # air live reload files
 !*/config/.air.toml
+
+# nginx config files
+!*/config/nginx.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - "8081:80"
     volumes:
       - ./pear/html:/usr/share/nginx/html
+      - ./pear/config/nginx.conf:/etc/nginx/conf.d/default.conf
 
   postgres:
     <<: *common

--- a/pear/config/nginx.conf
+++ b/pear/config/nginx.conf
@@ -1,0 +1,7 @@
+server {
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
Never serve 404, always serve `index.html`

Testing instructions:
1. `dc up --build pear`
2. Visit [`http://localhost:8081/`](http://localhost:8081/)
3. Visit [`http://localhost:8081/something`](http://localhost:8081/something)
4. Ensure you always get `index.html`