### PR TITLE
*: Add underline to all anchor tags

### DIFF
--- a/bean/internal/driver/template/_layout.html
+++ b/bean/internal/driver/template/_layout.html
@@ -72,7 +72,6 @@
 
       a {
         color: inherit;
-        text-decoration: none;
       }
 
       .container {

--- a/pear/html/index.html
+++ b/pear/html/index.html
@@ -96,10 +96,6 @@
         color: #063437;
       }
 
-      .footer a {
-        text-decoration: none;
-      }
-
       .header h1,
       .header h6,
       .footer p {


### PR DESCRIPTION
It's helpful to have any clickable link underlined

The change mainly affects the footer

![image](https://github.com/whatis277/harvest/assets/5631091/8c267a18-f253-4405-a636-342005c5d12a)

![image](https://github.com/whatis277/harvest/assets/5631091/d947ea01-800e-4e71-b24e-5a52119cdc70)