### PR TITLE
bean: Add basic paymentmethods page

### DIFF
--- a/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
+++ b/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
@@ -1,0 +1,44 @@
+package landing
+
+import (
+	"fmt"
+	"net/http"
+
+	"harvest/bean/internal/entity"
+
+	"harvest/bean/internal/usecase/paymentmethod"
+
+	"harvest/bean/internal/adapter/interfaces"
+)
+
+type handler struct {
+	usecase paymentmethod.UseCase
+
+	view interfaces.PaymentMethodsView
+}
+
+func New(
+	usecase paymentmethod.UseCase,
+	view interfaces.PaymentMethodsView,
+) http.Handler {
+	return &handler{
+		usecase: usecase,
+		view:    view,
+	}
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	methods, err := h.usecase.List("10000000-0000-0000-0000-000000000001")
+	if err != nil {
+		fmt.Fprintf(w, "Error: %v", err)
+		return
+	}
+
+	err = h.view.Render(w, &entity.PaymentMethodsViewData{
+		PaymentMethods: methods,
+	})
+	if err != nil {
+		fmt.Fprintf(w, "Error: %v", err)
+		return
+	}
+}

--- a/bean/internal/adapter/interfaces/interfaces.go
+++ b/bean/internal/adapter/interfaces/interfaces.go
@@ -15,3 +15,4 @@ type View[T any] interface {
 type LandingView View[entity.LandingViewData]
 type LoginView View[entity.LoginViewData]
 type SubscriptionsView View[entity.SubscriptionsViewData]
+type PaymentMethodsView View[entity.PaymentMethodsViewData]

--- a/bean/internal/driver/template/paymentmethods.html
+++ b/bean/internal/driver/template/paymentmethods.html
@@ -1,21 +1,20 @@
 {{ define "navbar" }}
-<a>Subscription</a>
+<a href="/subscriptions">Subscription</a>
 &nbsp;·&nbsp;
-<a href="/cards">Cards</a>
+<a>Cards</a>
 &nbsp;·&nbsp;
 <a href="/logout">Logout</a>
 {{ end }}
 
 {{ define "content" }}
 <div class="section">
-  {{ range .Subscriptions }}
+  {{ range .PaymentMethods }}
   <div class="subsection">
-    <p>Payment method id: {{ .PaymentMethodID }}</p>
     <p>Label: {{ .Label }}</p>
-    <p>Provider: {{ .Provider }}</p>
-    <p>Amount: {{ .Amount }}</p>
-    <p>Interval: {{ .Interval }}</p>
-    <p>Period: {{ .Period }}</p>
+    <p>Last4: {{ .Last4 }}</p>
+    <p>Brand: {{ .Brand }}</p>
+    <p>ExpMonth: {{ .ExpMonth }}</p>
+    <p>ExpYear: {{ .ExpYear }}</p>
     <p>Created at: {{ .CreatedAt }}</p>
   </div>
   {{ end }}

--- a/bean/internal/driver/template/template.go
+++ b/bean/internal/driver/template/template.go
@@ -26,4 +26,9 @@ var (
 		baseTemplate,
 		"subscriptions.html",
 	}
+
+	PaymentMethodsTemplate = []string{
+		baseTemplate,
+		"paymentmethods.html",
+	}
 )

--- a/bean/internal/driver/view/paymentmethods/paymentmethods.go
+++ b/bean/internal/driver/view/paymentmethods/paymentmethods.go
@@ -1,0 +1,9 @@
+package paymentmethods
+
+import (
+	"harvest/bean/internal/entity"
+
+	"harvest/bean/internal/driver/view"
+)
+
+var New = view.New[entity.PaymentMethodsViewData]

--- a/bean/internal/entity/entity.go
+++ b/bean/internal/entity/entity.go
@@ -83,6 +83,10 @@ type SubscriptionsViewData struct {
 	Subscriptions []*Subscription
 }
 
+type PaymentMethodsViewData struct {
+	PaymentMethods []*PaymentMethod
+}
+
 type ViewData interface{}
 
 var _ ViewData = LandingViewData{}

--- a/bean/internal/usecase/paymentmethod/paymentmethod.go
+++ b/bean/internal/usecase/paymentmethod/paymentmethod.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UseCase struct {
-	paymentMethods interfaces.PaymentMethodDataSource
+	PaymentMethods interfaces.PaymentMethodDataSource
 }
 
 func (u *UseCase) Create(
@@ -40,7 +40,7 @@ func (u *UseCase) Create(
 		return nil, fmt.Errorf("invalid exp year: %w", err)
 	}
 
-	method, err := u.paymentMethods.Create(userID, label, last4, brand, expMonth, expYear)
+	method, err := u.PaymentMethods.Create(userID, label, last4, brand, expMonth, expYear)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payment method: %w", err)
 	}
@@ -49,7 +49,7 @@ func (u *UseCase) Create(
 }
 
 func (u *UseCase) Get(userID string, paymentMethodID string) (*entity.PaymentMethod, error) {
-	method, err := u.paymentMethods.FindByID(userID, paymentMethodID)
+	method, err := u.PaymentMethods.FindByID(userID, paymentMethodID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment method: %w", err)
 	}
@@ -58,7 +58,7 @@ func (u *UseCase) Get(userID string, paymentMethodID string) (*entity.PaymentMet
 }
 
 func (u *UseCase) List(userID string) ([]*entity.PaymentMethod, error) {
-	methods, err := u.paymentMethods.FindByUserID(userID)
+	methods, err := u.PaymentMethods.FindByUserID(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list payment methods: %w", err)
 	}
@@ -67,7 +67,7 @@ func (u *UseCase) List(userID string) ([]*entity.PaymentMethod, error) {
 }
 
 func (u *UseCase) Delete(userID string, paymentMethodID string) error {
-	if err := u.paymentMethods.Delete(userID, paymentMethodID); err != nil {
+	if err := u.PaymentMethods.Delete(userID, paymentMethodID); err != nil {
 		return fmt.Errorf("failed to delete payment method: %w", err)
 	}
 


### PR DESCRIPTION
Adds basic payment methods page

Primitively lists all payment methods
User ID is hard coded

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. Visit [`/cards`](https://localhost/cards)
4. Ensure you can see the seeded data 

<img width="1280" alt="image" src="https://github.com/whatis277/harvest/assets/5631091/59c5889e-b0b7-4233-8c11-0076f5a6f7eb">
