### PR TITLE
bean: Add maintaining scroll pos

### DIFF
--- a/bean/internal/driver/template/layout/base.html
+++ b/bean/internal/driver/template/layout/base.html
@@ -171,6 +171,20 @@
         margin: 0;
       }
     </style>
+
+    <script>
+      // maintains scroll position on page reload
+
+      document.addEventListener("DOMContentLoaded", function (event) {
+        var scrollpos = localStorage.getItem("scrollpos");
+
+        if (scrollpos) window.scrollTo(0, scrollpos);
+      });
+
+      window.onbeforeunload = function (e) {
+        localStorage.setItem("scrollpos", window.scrollY);
+      };
+    </script>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
Maintains scroll position between reloads and page navigations

Not necessarily, but a nice touch

Testing instructions:
1. `dc up bean`
2. Visit [`/cards`](http://localhost:8080/cards)
3. Scroll a bit down
4. Click on Delete
5. Ensure the page reloaded
6. Ensure your scroll position doesn't change