### PR TITLE
bean: Fix opening sub provider in new tab

### DIFF
--- a/bean/internal/driver/template/subscriptions.html
+++ b/bean/internal/driver/template/subscriptions.html
@@ -18,7 +18,7 @@
   <div id="sub-{{ .ID }}" class="subsection">
     <h5>
       {{ if .Provider }}
-        <a href="{{ .Provider }}">{{ .Label }}</a>
+        <a target="_blank" href="{{ .Provider }}">{{ .Label }}</a>
       {{ else }}
         {{ .Label }}
       {{ end }}


### PR DESCRIPTION
The sub provider is an external link
It should be opened in a new tab

No testing needed