### PR TITLE
bean: Add redesigned single home page

### DIFF
--- a/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
+++ b/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
@@ -86,5 +86,39 @@ func (h *handler) makeMethodViewData(pm *entity.PaymentMethodWithSubscriptions) 
 
 		MonthlyEstimate: fmt.Sprintf("$%d.%02d", monthlyDollars, monthlyCents),
 		YearlyEstimate:  fmt.Sprintf("$%d.%02d", yearlyDollars, yearlyCents),
+
+		Subscriptions: h.makeSubsViewData(subs),
 	}
+}
+
+func (h *handler) makeSubsViewData(subs []*entity.Subscription) []entity.SubscriptionViewData {
+	viewdata := make([]entity.SubscriptionViewData, 0, len(subs))
+
+	for _, sub := range subs {
+		viewdata = append(viewdata, h.makeSubViewData(sub))
+	}
+
+	return viewdata
+}
+
+func (h *handler) makeSubViewData(subscription *entity.Subscription) entity.SubscriptionViewData {
+	dollars, cents := subscription.Amount/100, subscription.Amount%100
+
+	frequency := makeFrequency(subscription.Interval, subscription.Period)
+
+	return entity.SubscriptionViewData{
+		ID:        subscription.ID,
+		Label:     subscription.Label,
+		Provider:  subscription.Provider,
+		Amount:    fmt.Sprintf("$%d.%02d", dollars, cents),
+		Frequency: frequency,
+	}
+}
+
+func makeFrequency(interval int, period entity.SubscriptionPeriod) string {
+	if interval == 1 {
+		return fmt.Sprintf("Every %s", period)
+	}
+
+	return fmt.Sprintf("Every %d %ss", interval, period)
 }

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -60,7 +60,8 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 				" payment_methods.id, payment_methods.user_id," +
 				" payment_methods.label, payment_methods.last4, payment_methods.brand, payment_methods.exp_month, payment_methods.exp_year," +
 				" payment_methods.created_at, payment_methods.updated_at," +
-				" subscriptions.id, subscriptions.label, subscriptions.amount, subscriptions.interval, subscriptions.period" +
+				" subscriptions.id, subscriptions.label, subscriptions.provider," +
+				" subscriptions.amount, subscriptions.interval, subscriptions.period" +
 				" FROM payment_methods" +
 				" LEFT JOIN subscriptions" +
 				" ON payment_methods.id = subscriptions.payment_method_id" +
@@ -87,6 +88,7 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 		var (
 			subID       *string
 			subLabel    *string
+			subProvider *string
 			subAmount   *int
 			subInterval *int
 			subPeriod   *string
@@ -96,7 +98,8 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 			&method.ID, &method.UserID,
 			&method.Label, &method.Last4, &method.Brand, &method.ExpMonth, &method.ExpYear,
 			&method.CreatedAt, &method.UpdatedAt,
-			&subID, &subLabel, &subAmount, &subInterval, &subPeriod,
+			&subID, &subLabel, &subProvider,
+			&subAmount, &subInterval, &subPeriod,
 		)
 
 		if err != nil {
@@ -107,6 +110,7 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 		if subID != nil {
 			sub.ID = *subID
 			sub.Label = *subLabel
+			sub.Provider = *subProvider
 			sub.Amount = *subAmount
 			sub.Interval = *subInterval
 			sub.Period = entity.SubscriptionPeriod(*subPeriod)
@@ -131,7 +135,8 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 				" payment_methods.id, payment_methods.user_id," +
 				" payment_methods.label, payment_methods.last4, payment_methods.brand, payment_methods.exp_month, payment_methods.exp_year," +
 				" payment_methods.created_at, payment_methods.updated_at," +
-				" subscriptions.id, subscriptions.label, subscriptions.amount, subscriptions.interval, subscriptions.period" +
+				" subscriptions.id, subscriptions.label, subscriptions.provider," +
+				" subscriptions.amount, subscriptions.interval, subscriptions.period" +
 				" FROM payment_methods" +
 				" LEFT JOIN subscriptions" +
 				" ON payment_methods.id = subscriptions.payment_method_id" +
@@ -158,6 +163,7 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 		var (
 			subID       *string
 			subLabel    *string
+			subProvider *string
 			subAmount   *int
 			subInterval *int
 			subPeriod   *string
@@ -167,7 +173,8 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 			&method.ID, &method.UserID,
 			&method.Label, &method.Last4, &method.Brand, &method.ExpMonth, &method.ExpYear,
 			&method.CreatedAt, &method.UpdatedAt,
-			&subID, &subLabel, &subAmount, &subInterval, &subPeriod,
+			&subID, &subLabel, &subProvider,
+			&subAmount, &subInterval, &subPeriod,
 		)
 
 		if err != nil {
@@ -178,6 +185,7 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 		if subID != nil {
 			sub.ID = *subID
 			sub.Label = *subLabel
+			sub.Provider = *subProvider
 			sub.Amount = *subAmount
 			sub.Interval = *subInterval
 			sub.Period = entity.SubscriptionPeriod(*subPeriod)

--- a/bean/internal/driver/template/paymentmethods.html
+++ b/bean/internal/driver/template/paymentmethods.html
@@ -1,12 +1,68 @@
 {{ define "navbar" }}
-<a href="/subscriptions">Subscription</a>
-&nbsp;·&nbsp;
-<a>Cards</a>
+<a target="_blank" href="https://todo-stripe-link">Subscription</a>
 &nbsp;·&nbsp;
 <a href="/logout">Logout</a>
 {{ end }}
 
 {{ define "content" }}
+<style>
+summary > h1,
+summary > h2,
+summary > h3,
+summary > h4,
+summary > h5 {
+  display: inline;
+
+  margin-left: 0.5em;
+
+  cursor: pointer;
+}
+
+ul {
+  list-style: none;
+
+  padding: 0;
+  margin: 0;
+}
+
+hr {
+  opacity: 0.4;
+}
+
+.card-content {
+  position: relative;
+}
+
+.card-content:nth-of-type(odd)::before {
+  content: "";
+
+  background-color: #f9f9f9;
+
+  width: 100vw;
+  height: 100%;
+
+  position: absolute;
+  z-index: -1;
+
+  top: 0;
+  /*
+   * The left value is calculated as follows.
+   * 
+   * We know the container width is min(100%, 36em).
+   * 
+   * Thus, we know the area outside the container.
+   * That is 100vw - min(100%, 36em).
+   * 
+   * But that area is to the left and right of the container.
+   * The container is centered, so they are equal. 
+   * So, we split it in half.
+   * 
+   * Then, we subtract that from 0rem to get the negative value.
+   */
+  left: calc(0rem - calc((100vw - min(100%, 36em)) / 2));
+}
+</style>
+
 <div class="section">
   <div class="subsection">
     <h3>Total spending</h3>
@@ -19,39 +75,92 @@
 </div>
 
 <div class="section">
-  <div class="subsection">
-    <p class="actionbar">
-      <a href="/cards/new">Add a new card</a>
-    </p>
-  </div>
+  <p>
+    <a href="/todo">Add a new card</a>
+  </p>
+</div>
 
+<div class="section">
   {{ range .PaymentMethods }}
-  <div id="card-{{ .ID }}" class="subsection">
-    <hr /><br /><br />
-    <h5>{{ .Label }}</h5>
-    <p>
-      {{ .Last4 }}
-      &nbsp;·&nbsp;
-      {{ .ExpMonth }} / {{ .ExpYear }}
-      &nbsp;·&nbsp;
-      {{ .Brand }}
-    </p>
-    <p>
-      {{ .MonthlyEstimate }} monthly
-      &nbsp;·&nbsp;
-      {{ .YearlyEstimate }} yearly
-    </p>
-    <br />
-    <p class="actionbar">
-      <label for="delete-card-{{ .ID }}">Delete</label>
-    </p>
-
-    <form class="hidden" method="post">
-      <input type="hidden" name="_method" value="delete" />
-      <input type="hidden" name="id" value="{{ .ID }}" />
-      <input id="delete-card-{{ .ID }}" type="submit" value="Delete" />
-    </form>
-  </div>
+  {{ template "card-content" . }}
   {{ end }}
 </div>
+{{ end }}
+
+{{ define "card-content" }}
+<div class="card-content">
+  <br /><br />
+  <details id="card-{{ .ID }}">
+    <summary>
+      {{ template "card-summary" . }}
+    </summary>
+
+    <br />
+
+    <div>
+      <p class="actionbar">
+        <a href="/todo">Delete card</a>
+      </p>
+    </div>
+
+    <br />
+
+    <div>
+      <p class="actionbar">
+        <a href="/todo">Add a new subscription</a>
+      </p>
+    </div>
+
+    <br />
+
+    <ul>
+      {{ if .Subscriptions }}
+      {{ range .Subscriptions }}
+      <hr /><br />
+      {{ template "subscription" . }}
+      <br />
+      {{ end }}
+      {{ else }}
+      <li class="subscription">
+        <hr /><br />
+        <p><em>No subscriptions</em></p>
+        <br />
+      {{ end }}
+    </ul>
+  </details>
+  <br /><br />
+</div>
+{{ end }}
+
+{{ define "card-summary" }}
+<h4>{{ .Label }}</h4>
+<br /><br />
+<p>
+  {{ .Last4 }}
+  &nbsp;·&nbsp;
+  {{ .ExpMonth }} / {{ .ExpYear }}
+  &nbsp;·&nbsp;
+  {{ .Brand }}
+</p>
+<p>
+  {{ .MonthlyEstimate }} monthly
+  &nbsp;·&nbsp;
+  {{ .YearlyEstimate }} yearly
+</p>
+{{ end }}
+
+{{ define "subscription" }}
+<li id="sub-{{ .ID }}">
+  <p><strong>{{ .Label }}</strong></p>
+  <p>
+    {{ .Amount }} &nbsp;·&nbsp; {{ .Frequency }}
+  </p>
+  <p class="actionbar">
+    {{ if .Provider }}
+    <a href="{{ .Provider }}">Unsubscribe</a>
+    &nbsp;·&nbsp;
+    {{ end }}
+    <a href="/todo">Delete</a>
+  </p>
+</li>
 {{ end }}

--- a/bean/internal/entity/entity.go
+++ b/bean/internal/entity/entity.go
@@ -148,6 +148,8 @@ type PaymentMethodViewData struct {
 
 	MonthlyEstimate string
 	YearlyEstimate  string
+
+	Subscriptions []SubscriptionViewData
 }
 
 // --- Misc ---


### PR DESCRIPTION
Uses a single page instead of the previous 2 page solution (subs, cards)

Lists all cards, under each card its subs

Also ensures the design is accessible via keyboard only

Clean-up of unused code will be code in a follow-up PR

No testing needed

https://github.com/whatis277/harvest/assets/5631091/9e3c4a97-86ba-46cb-b3b9-ce3d75d88a29