### PR TITLE
bean: Add separation between entities

### DIFF
--- a/bean/internal/adapter/handler/login/login.go
+++ b/bean/internal/adapter/handler/login/login.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/adapter/interfaces"
 )
@@ -26,7 +26,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.view.Render(w, &entity.LoginViewData{
+	err := h.view.Render(w, &viewmodel.LoginViewData{
 		Email: email,
 	})
 	if err != nil {

--- a/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
+++ b/bean/internal/adapter/handler/paymentmethods/paymentmethods.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
+	"harvest/bean/internal/entity/viewmodel"
 
 	estimatorUC "harvest/bean/internal/usecase/estimator"
 	"harvest/bean/internal/usecase/paymentmethod"
@@ -46,8 +47,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *handler) makeViewData(paymentMethods []*entity.PaymentMethodWithSubscriptions) *entity.PaymentMethodsViewData {
-	methods := make([]entity.PaymentMethodViewData, 0, len(paymentMethods))
+func (h *handler) makeViewData(paymentMethods []*model.PaymentMethodWithSubscriptions) *viewmodel.PaymentMethodsViewData {
+	methods := make([]viewmodel.PaymentMethodViewData, 0, len(paymentMethods))
 	monthly, yearly := 0, 0
 
 	for _, method := range paymentMethods {
@@ -59,7 +60,7 @@ func (h *handler) makeViewData(paymentMethods []*entity.PaymentMethodWithSubscri
 		methods = append(methods, makeMethodViewData(method, estimates))
 	}
 
-	return &entity.PaymentMethodsViewData{
+	return &viewmodel.PaymentMethodsViewData{
 		PaymentMethods:  methods,
 		MonthlyEstimate: toDollarsString(monthly),
 		YearlyEstimate:  toDollarsString(yearly),
@@ -67,9 +68,9 @@ func (h *handler) makeViewData(paymentMethods []*entity.PaymentMethodWithSubscri
 }
 
 func makeMethodViewData(
-	pm *entity.PaymentMethodWithSubscriptions,
-	estimates *entity.Estimates,
-) entity.PaymentMethodViewData {
+	pm *model.PaymentMethodWithSubscriptions,
+	estimates *model.Estimates,
+) viewmodel.PaymentMethodViewData {
 	method, subs := pm.PaymentMethod, pm.Subscriptions
 
 	label := method.Label
@@ -77,7 +78,7 @@ func makeMethodViewData(
 		label = fmt.Sprintf("Card %s", method.Last4)
 	}
 
-	return entity.PaymentMethodViewData{
+	return viewmodel.PaymentMethodViewData{
 		ID:       method.ID,
 		Label:    label,
 		Last4:    method.Last4,
@@ -92,8 +93,8 @@ func makeMethodViewData(
 	}
 }
 
-func makeSubsViewData(subscriptions []*entity.Subscription) []entity.SubscriptionViewData {
-	subs := make([]entity.SubscriptionViewData, 0, len(subscriptions))
+func makeSubsViewData(subscriptions []*model.Subscription) []viewmodel.SubscriptionViewData {
+	subs := make([]viewmodel.SubscriptionViewData, 0, len(subscriptions))
 	for _, sub := range subscriptions {
 		subs = append(subs, makeSubViewData(sub))
 	}
@@ -101,7 +102,7 @@ func makeSubsViewData(subscriptions []*entity.Subscription) []entity.Subscriptio
 	return subs
 }
 
-func makeSubViewData(subscription *entity.Subscription) entity.SubscriptionViewData {
+func makeSubViewData(subscription *model.Subscription) viewmodel.SubscriptionViewData {
 	label := subscription.Label
 	provider := subscription.Provider
 
@@ -110,7 +111,7 @@ func makeSubViewData(subscription *entity.Subscription) entity.SubscriptionViewD
 		label = u.Host
 	}
 
-	return entity.SubscriptionViewData{
+	return viewmodel.SubscriptionViewData{
 		ID:        subscription.ID,
 		Label:     label,
 		Provider:  provider,
@@ -119,7 +120,7 @@ func makeSubViewData(subscription *entity.Subscription) entity.SubscriptionViewD
 	}
 }
 
-func toFrequencyString(interval int, period entity.SubscriptionPeriod) string {
+func toFrequencyString(interval int, period model.SubscriptionPeriod) string {
 	if interval == 1 {
 		return fmt.Sprintf("Every %s", period)
 	}

--- a/bean/internal/adapter/interfaces/interfaces.go
+++ b/bean/internal/adapter/interfaces/interfaces.go
@@ -3,7 +3,7 @@ package interfaces
 import (
 	"net/http"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 )
 
 // --- Views ---
@@ -12,6 +12,6 @@ type View[T any] interface {
 	Render(http.ResponseWriter, *T) error
 }
 
-type LandingView View[entity.LandingViewData]
-type LoginView View[entity.LoginViewData]
-type PaymentMethodsView View[entity.PaymentMethodsViewData]
+type LandingView View[viewmodel.LandingViewData]
+type LoginView View[viewmodel.LoginViewData]
+type PaymentMethodsView View[viewmodel.PaymentMethodsViewData]

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -25,11 +25,11 @@ func (ds *dataSource) Create(
 	userID string,
 	label string,
 	last4 string,
-	brand entity.PaymentMethodBrand,
+	brand model.PaymentMethodBrand,
 	expMonth int,
 	expYear int,
-) (*entity.PaymentMethod, error) {
-	method := &entity.PaymentMethod{}
+) (*model.PaymentMethod, error) {
+	method := &model.PaymentMethod{}
 
 	err := ds.db.Pool.
 		QueryRow(
@@ -52,7 +52,7 @@ func (ds *dataSource) Create(
 	return method, nil
 }
 
-func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodWithSubscriptions, error) {
+func (ds *dataSource) FindByID(userID string, id string) (*model.PaymentMethodWithSubscriptions, error) {
 	rows, err := ds.db.Pool.
 		Query(
 			context.Background(),
@@ -81,8 +81,8 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 
 	defer rows.Close()
 
-	method := &entity.PaymentMethod{}
-	subs := []*entity.Subscription{}
+	method := &model.PaymentMethod{}
+	subs := []*model.Subscription{}
 
 	for rows.Next() {
 		var (
@@ -106,14 +106,14 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 			return nil, fmt.Errorf("failed to scan payment method: %w", err)
 		}
 
-		sub := &entity.Subscription{}
+		sub := &model.Subscription{}
 		if subID != nil {
 			sub.ID = *subID
 			sub.Label = *subLabel
 			sub.Provider = *subProvider
 			sub.Amount = *subAmount
 			sub.Interval = *subInterval
-			sub.Period = entity.SubscriptionPeriod(*subPeriod)
+			sub.Period = model.SubscriptionPeriod(*subPeriod)
 		}
 
 		if sub.ID != "" {
@@ -121,13 +121,13 @@ func (ds *dataSource) FindByID(userID string, id string) (*entity.PaymentMethodW
 		}
 	}
 
-	return &entity.PaymentMethodWithSubscriptions{
+	return &model.PaymentMethodWithSubscriptions{
 		PaymentMethod: method,
 		Subscriptions: subs,
 	}, nil
 }
 
-func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSubscriptions, error) {
+func (ds *dataSource) FindByUserID(userID string) ([]*model.PaymentMethodWithSubscriptions, error) {
 	rows, err := ds.db.Pool.
 		Query(
 			context.Background(),
@@ -152,14 +152,14 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 
 	defer rows.Close()
 
-	methods := []*entity.PaymentMethodWithSubscriptions{}
-	cache := &entity.PaymentMethodWithSubscriptions{
-		PaymentMethod: &entity.PaymentMethod{},
-		Subscriptions: []*entity.Subscription{},
+	methods := []*model.PaymentMethodWithSubscriptions{}
+	cache := &model.PaymentMethodWithSubscriptions{
+		PaymentMethod: &model.PaymentMethod{},
+		Subscriptions: []*model.Subscription{},
 	}
 
 	for rows.Next() {
-		method := &entity.PaymentMethod{}
+		method := &model.PaymentMethod{}
 		var (
 			subID       *string
 			subLabel    *string
@@ -181,14 +181,14 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 			return nil, fmt.Errorf("failed to scan payment method: %w", err)
 		}
 
-		sub := &entity.Subscription{}
+		sub := &model.Subscription{}
 		if subID != nil {
 			sub.ID = *subID
 			sub.Label = *subLabel
 			sub.Provider = *subProvider
 			sub.Amount = *subAmount
 			sub.Interval = *subInterval
-			sub.Period = entity.SubscriptionPeriod(*subPeriod)
+			sub.Period = model.SubscriptionPeriod(*subPeriod)
 		}
 
 		if cache.PaymentMethod.ID == "" {
@@ -198,9 +198,9 @@ func (ds *dataSource) FindByUserID(userID string) ([]*entity.PaymentMethodWithSu
 		if cache.PaymentMethod.ID != method.ID {
 			methods = append(methods, cache)
 
-			cache = &entity.PaymentMethodWithSubscriptions{
+			cache = &model.PaymentMethodWithSubscriptions{
 				PaymentMethod: method,
-				Subscriptions: []*entity.Subscription{},
+				Subscriptions: []*model.Subscription{},
 			}
 		}
 

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
@@ -3,7 +3,7 @@ package paymentmethod
 import (
 	"testing"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -40,7 +40,7 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
-	method, err := ds.Create(userWithMethodsID, "action-create", "1234", entity.PaymentMethodBrandAmex, 12, 2024)
+	method, err := ds.Create(userWithMethodsID, "action-create", "1234", model.PaymentMethodBrandAmex, 12, 2024)
 	if err != nil {
 		t.Fatalf("failed to create payment method: %s", err)
 	}
@@ -61,8 +61,8 @@ func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 		t.Errorf("expected last4: %s, got: %s", "1234", method.Last4)
 	}
 
-	if method.Brand != entity.PaymentMethodBrandAmex {
-		t.Errorf("expected brand: %s, got: %s", entity.PaymentMethodBrandAmex, method.Brand)
+	if method.Brand != model.PaymentMethodBrandAmex {
+		t.Errorf("expected brand: %s, got: %s", model.PaymentMethodBrandAmex, method.Brand)
 	}
 
 	if method.ExpMonth != 12 {
@@ -165,7 +165,7 @@ func findByUserID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 
 func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	t.Run("existing_payment_method", func(t *testing.T) {
-		method, err := ds.Create(userWithMethodsID, "action-delete", "1234", entity.PaymentMethodBrandAmex, 12, 2024)
+		method, err := ds.Create(userWithMethodsID, "action-delete", "1234", model.PaymentMethodBrandAmex, 12, 2024)
 		if err != nil {
 			t.Fatalf("failed to create payment method: %s", err)
 		}

--- a/bean/internal/driver/datasource/subscription/subscription.go
+++ b/bean/internal/driver/datasource/subscription/subscription.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -30,9 +30,9 @@ func (ds *dataSource) Create(
 	provider string,
 	amount int,
 	interval int,
-	period entity.SubscriptionPeriod,
-) (*entity.Subscription, error) {
-	sub := &entity.Subscription{}
+	period model.SubscriptionPeriod,
+) (*model.Subscription, error) {
+	sub := &model.Subscription{}
 
 	err := ds.db.Pool.
 		QueryRow(
@@ -57,8 +57,8 @@ func (ds *dataSource) Create(
 	return sub, nil
 }
 
-func (ds *dataSource) FindByID(userID string, id string) (*entity.Subscription, error) {
-	sub := &entity.Subscription{}
+func (ds *dataSource) FindByID(userID string, id string) (*model.Subscription, error) {
+	sub := &model.Subscription{}
 
 	err := ds.db.Pool.
 		QueryRow(

--- a/bean/internal/driver/datasource/subscription/subscription_test.go
+++ b/bean/internal/driver/datasource/subscription/subscription_test.go
@@ -3,7 +3,8 @@ package subscription
 import (
 	"testing"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
+
 	"harvest/bean/internal/usecase/interfaces"
 
 	"harvest/bean/internal/driver/postgres/postgrestest"
@@ -37,7 +38,7 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
-	sub, err := ds.Create(userWithSubsID, methodID, "action-create", "bean", 1000, 1, entity.SubscriptionPeriodMonthly)
+	sub, err := ds.Create(userWithSubsID, methodID, "action-create", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
 	if err != nil {
 		t.Fatalf("failed to create subscription: %s", err)
 	}
@@ -70,8 +71,8 @@ func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
 		t.Errorf("expected interval: %d, got: %d", 1, sub.Interval)
 	}
 
-	if sub.Period != entity.SubscriptionPeriodMonthly {
-		t.Errorf("expected period: %s, got: %s", entity.SubscriptionPeriodMonthly, sub.Period)
+	if sub.Period != model.SubscriptionPeriodMonthly {
+		t.Errorf("expected period: %s, got: %s", model.SubscriptionPeriodMonthly, sub.Period)
 	}
 
 	if err := ds.Delete(userWithSubsID, sub.ID); err != nil {
@@ -116,7 +117,7 @@ func findByID(t *testing.T, ds interfaces.SubscriptionDataSource) {
 
 func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	t.Run("existing_subscription", func(t *testing.T) {
-		sub, err := ds.Create(userWithSubsID, methodID, "action-delete", "bean", 1000, 1, entity.SubscriptionPeriodMonthly)
+		sub, err := ds.Create(userWithSubsID, methodID, "action-delete", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
 		if err != nil {
 			t.Fatalf("failed to create subscription: %s", err)
 		}

--- a/bean/internal/driver/datasource/token/token.go
+++ b/bean/internal/driver/datasource/token/token.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -23,8 +23,8 @@ func New(db *postgres.DB) interfaces.LoginTokenDataSource {
 	}
 }
 
-func (ds *dataSource) Create(email string, hashedToken string) (*entity.LoginToken, error) {
-	token := &entity.LoginToken{}
+func (ds *dataSource) Create(email string, hashedToken string) (*model.LoginToken, error) {
+	token := &model.LoginToken{}
 
 	err := ds.db.Pool.
 		QueryRow(
@@ -45,8 +45,8 @@ func (ds *dataSource) Create(email string, hashedToken string) (*entity.LoginTok
 	return token, nil
 }
 
-func (ds *dataSource) FindUnexpired(id string) (*entity.LoginToken, error) {
-	token := &entity.LoginToken{}
+func (ds *dataSource) FindUnexpired(id string) (*model.LoginToken, error) {
+	token := &model.LoginToken{}
 
 	err := ds.db.Pool.
 		QueryRow(

--- a/bean/internal/driver/datasource/user/user.go
+++ b/bean/internal/driver/datasource/user/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -23,8 +23,8 @@ func New(db *postgres.DB) interfaces.UserDataSource {
 	}
 }
 
-func (ds *dataSource) Create(email string) (*entity.User, error) {
-	user := &entity.User{}
+func (ds *dataSource) Create(email string) (*model.User, error) {
+	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(
@@ -43,8 +43,8 @@ func (ds *dataSource) Create(email string) (*entity.User, error) {
 	return user, nil
 }
 
-func (ds *dataSource) FindById(id string) (*entity.User, error) {
-	user := &entity.User{}
+func (ds *dataSource) FindById(id string) (*model.User, error) {
+	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(
@@ -65,8 +65,8 @@ func (ds *dataSource) FindById(id string) (*entity.User, error) {
 	return user, nil
 }
 
-func (ds *dataSource) FindByEmail(email string) (*entity.User, error) {
-	user := &entity.User{}
+func (ds *dataSource) FindByEmail(email string) (*model.User, error) {
+	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(

--- a/bean/internal/driver/view/landing/landing.go
+++ b/bean/internal/driver/view/landing/landing.go
@@ -1,9 +1,9 @@
 package landing
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/driver/view"
 )
 
-var New = view.New[entity.LandingViewData]
+var New = view.New[viewmodel.LandingViewData]

--- a/bean/internal/driver/view/login/login.go
+++ b/bean/internal/driver/view/login/login.go
@@ -1,9 +1,9 @@
 package login
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/driver/view"
 )
 
-var New = view.New[entity.LoginViewData]
+var New = view.New[viewmodel.LoginViewData]

--- a/bean/internal/driver/view/paymentmethods/paymentmethods.go
+++ b/bean/internal/driver/view/paymentmethods/paymentmethods.go
@@ -1,9 +1,9 @@
 package paymentmethods
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/driver/view"
 )
 
-var New = view.New[entity.PaymentMethodsViewData]
+var New = view.New[viewmodel.PaymentMethodsViewData]

--- a/bean/internal/driver/view/view.go
+++ b/bean/internal/driver/view/view.go
@@ -6,16 +6,16 @@ import (
 	"html/template"
 	"net/http"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/adapter/interfaces"
 )
 
-type Base[T entity.ViewData] struct {
+type Base[T viewmodel.ViewData] struct {
 	tmpl *template.Template
 }
 
-func New[T entity.ViewData](FS embed.FS, templates []string) (interfaces.View[T], error) {
+func New[T viewmodel.ViewData](FS embed.FS, templates []string) (interfaces.View[T], error) {
 	tmpl, err := template.ParseFS(FS, templates...)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing templates: %w", err)

--- a/bean/internal/entity/model/model.go
+++ b/bean/internal/entity/model/model.go
@@ -1,4 +1,4 @@
-package entity
+package model
 
 import (
 	"time"
@@ -82,53 +82,6 @@ type LoginToken struct {
 
 	CreatedAt time.Time
 	ExpiresAt time.Time
-}
-
-// --- View Data ---
-
-type ViewData interface{}
-
-// --- View Data --- Landing ---
-
-type LandingViewData struct{}
-
-// --- View Data --- Login ---
-
-type LoginViewData struct {
-	Email string
-}
-
-// --- View Data --- Payment Methods ---
-
-type PaymentMethodsViewData struct {
-	PaymentMethods []PaymentMethodViewData
-
-	MonthlyEstimate string
-	YearlyEstimate  string
-}
-
-type PaymentMethodViewData struct {
-	ID string
-
-	Label    string
-	Last4    string
-	Brand    string
-	ExpMonth int
-	ExpYear  int
-
-	MonthlyEstimate string
-	YearlyEstimate  string
-
-	Subscriptions []SubscriptionViewData
-}
-
-type SubscriptionViewData struct {
-	ID string
-
-	Label     string
-	Provider  string
-	Amount    string
-	Frequency string
 }
 
 // --- Misc ---

--- a/bean/internal/entity/viewmodel/view.go
+++ b/bean/internal/entity/viewmodel/view.go
@@ -1,0 +1,48 @@
+package viewmodel
+
+// --- View Data ---
+
+type ViewData interface{}
+
+// --- View Data --- Landing ---
+
+type LandingViewData struct{}
+
+// --- View Data --- Login ---
+
+type LoginViewData struct {
+	Email string
+}
+
+// --- View Data --- Payment Methods ---
+
+type PaymentMethodsViewData struct {
+	PaymentMethods []PaymentMethodViewData
+
+	MonthlyEstimate string
+	YearlyEstimate  string
+}
+
+type PaymentMethodViewData struct {
+	ID string
+
+	Label    string
+	Last4    string
+	Brand    string
+	ExpMonth int
+	ExpYear  int
+
+	MonthlyEstimate string
+	YearlyEstimate  string
+
+	Subscriptions []SubscriptionViewData
+}
+
+type SubscriptionViewData struct {
+	ID string
+
+	Label     string
+	Provider  string
+	Amount    string
+	Frequency string
+}

--- a/bean/internal/usecase/estimator/estimator.go
+++ b/bean/internal/usecase/estimator/estimator.go
@@ -1,13 +1,13 @@
 package userdash
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 type UseCase struct{}
 
-func (u *UseCase) GetEstimates(subs []*entity.Subscription) *entity.Estimates {
-	estimates := &entity.Estimates{
+func (u *UseCase) GetEstimates(subs []*model.Subscription) *model.Estimates {
+	estimates := &model.Estimates{
 		Daily:   0,
 		Weekly:  0,
 		Monthly: 0,

--- a/bean/internal/usecase/estimator/utils.go
+++ b/bean/internal/usecase/estimator/utils.go
@@ -1,28 +1,28 @@
 package userdash
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
-func getSubscriptionEstimates(sub *entity.Subscription) *entity.Estimates {
-	e := &entity.Estimates{}
+func getSubscriptionEstimates(sub *model.Subscription) *model.Estimates {
+	e := &model.Estimates{}
 
 	switch sub.Period {
-	case entity.SubscriptionPeriodDaily:
+	case model.SubscriptionPeriodDaily:
 		e = getEstimatesFromDaily(sub.Amount)
-	case entity.SubscriptionPeriodWeekly:
+	case model.SubscriptionPeriodWeekly:
 		e = getEstimatesFromWeekly(sub.Amount)
-	case entity.SubscriptionPeriodMonthly:
+	case model.SubscriptionPeriodMonthly:
 		e = getEstimatesFromMonthly(sub.Amount)
-	case entity.SubscriptionPeriodYearly:
+	case model.SubscriptionPeriodYearly:
 		e = getEstimatesFromYearly(sub.Amount)
 	}
 
 	return e
 }
 
-func getEstimatesFromDaily(amount int) *entity.Estimates {
-	return &entity.Estimates{
+func getEstimatesFromDaily(amount int) *model.Estimates {
+	return &model.Estimates{
 		Daily:   amount,
 		Weekly:  amount * 7,
 		Monthly: amount * 30,
@@ -30,8 +30,8 @@ func getEstimatesFromDaily(amount int) *entity.Estimates {
 	}
 }
 
-func getEstimatesFromWeekly(amount int) *entity.Estimates {
-	return &entity.Estimates{
+func getEstimatesFromWeekly(amount int) *model.Estimates {
+	return &model.Estimates{
 		Daily:   amount / 7,
 		Weekly:  amount,
 		Monthly: amount * 4,
@@ -39,8 +39,8 @@ func getEstimatesFromWeekly(amount int) *entity.Estimates {
 	}
 }
 
-func getEstimatesFromMonthly(amount int) *entity.Estimates {
-	return &entity.Estimates{
+func getEstimatesFromMonthly(amount int) *model.Estimates {
+	return &model.Estimates{
 		Daily:   amount / 30,
 		Weekly:  amount / 4,
 		Monthly: amount,
@@ -48,8 +48,8 @@ func getEstimatesFromMonthly(amount int) *entity.Estimates {
 	}
 }
 
-func getEstimatesFromYearly(amount int) *entity.Estimates {
-	return &entity.Estimates{
+func getEstimatesFromYearly(amount int) *model.Estimates {
+	return &model.Estimates{
 		Daily:   amount / 365,
 		Weekly:  amount / 52,
 		Monthly: amount / 12,

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -1,7 +1,7 @@
 package interfaces
 
 import (
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 // --- Data Sources ---
@@ -14,10 +14,10 @@ type SubscriptionDataSource interface {
 		provider string,
 		amount int,
 		interval int,
-		period entity.SubscriptionPeriod,
-	) (*entity.Subscription, error)
+		period model.SubscriptionPeriod,
+	) (*model.Subscription, error)
 
-	FindByID(userID string, id string) (*entity.Subscription, error)
+	FindByID(userID string, id string) (*model.Subscription, error)
 
 	Delete(userID string, id string) error
 }
@@ -27,30 +27,30 @@ type PaymentMethodDataSource interface {
 		userID string,
 		label string,
 		last4 string,
-		brand entity.PaymentMethodBrand,
+		brand model.PaymentMethodBrand,
 		expMonth int,
 		expYear int,
-	) (*entity.PaymentMethod, error)
+	) (*model.PaymentMethod, error)
 
-	FindByID(userID string, id string) (*entity.PaymentMethodWithSubscriptions, error)
-	FindByUserID(userID string) ([]*entity.PaymentMethodWithSubscriptions, error)
+	FindByID(userID string, id string) (*model.PaymentMethodWithSubscriptions, error)
+	FindByUserID(userID string) ([]*model.PaymentMethodWithSubscriptions, error)
 
 	Delete(userID string, id string) error
 }
 
 type UserDataSource interface {
-	Create(email string) (*entity.User, error)
+	Create(email string) (*model.User, error)
 
-	FindById(id string) (*entity.User, error)
-	FindByEmail(email string) (*entity.User, error)
+	FindById(id string) (*model.User, error)
+	FindByEmail(email string) (*model.User, error)
 
 	Delete(id string) error
 }
 
 type LoginTokenDataSource interface {
-	Create(email string, hashedToken string) (*entity.LoginToken, error)
+	Create(email string, hashedToken string) (*model.LoginToken, error)
 
-	FindUnexpired(id string) (*entity.LoginToken, error)
+	FindUnexpired(id string) (*model.LoginToken, error)
 
 	Delete(id string) error
 }

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -3,7 +3,7 @@ package passwordless
 import (
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 
@@ -54,7 +54,7 @@ func (u *UseCase) SendEmail(email string) error {
 	return nil
 }
 
-func (u *UseCase) Login(id string, password string) (*entity.User, error) {
+func (u *UseCase) Login(id string, password string) (*model.User, error) {
 	hash, err := u.hasher.Hash(password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
@@ -79,7 +79,7 @@ func (u *UseCase) Login(id string, password string) (*entity.User, error) {
 	return user, nil
 }
 
-func (u *UseCase) findOrCreateUser(email string) (*entity.User, error) {
+func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
 	user, err := u.users.FindByEmail(email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user: %w", err)

--- a/bean/internal/usecase/paymentmethod/paymentmethod.go
+++ b/bean/internal/usecase/paymentmethod/paymentmethod.go
@@ -3,7 +3,7 @@ package paymentmethod
 import (
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 )
@@ -16,10 +16,10 @@ func (u *UseCase) Create(
 	userID string,
 	label string,
 	last4 string,
-	brand entity.PaymentMethodBrand,
+	brand model.PaymentMethodBrand,
 	expMonth int,
 	expYear int,
-) (*entity.PaymentMethod, error) {
+) (*model.PaymentMethod, error) {
 	if err := validateLabel(label); err != nil {
 		return nil, fmt.Errorf("invalid label: %w", err)
 	}
@@ -48,7 +48,7 @@ func (u *UseCase) Create(
 	return method, nil
 }
 
-func (u *UseCase) Get(userID string, paymentMethodID string) (*entity.PaymentMethodWithSubscriptions, error) {
+func (u *UseCase) Get(userID string, paymentMethodID string) (*model.PaymentMethodWithSubscriptions, error) {
 	method, err := u.PaymentMethods.FindByID(userID, paymentMethodID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment method: %w", err)
@@ -57,7 +57,7 @@ func (u *UseCase) Get(userID string, paymentMethodID string) (*entity.PaymentMet
 	return method, nil
 }
 
-func (u *UseCase) List(userID string) ([]*entity.PaymentMethodWithSubscriptions, error) {
+func (u *UseCase) List(userID string) ([]*model.PaymentMethodWithSubscriptions, error) {
 	methods, err := u.PaymentMethods.FindByUserID(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list payment methods: %w", err)

--- a/bean/internal/usecase/paymentmethod/validation.go
+++ b/bean/internal/usecase/paymentmethod/validation.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 func validateLabel(label string) error {
@@ -28,18 +28,18 @@ func validateLast4(last4 string) error {
 	return nil
 }
 
-func validateBrand(brand entity.PaymentMethodBrand) error {
+func validateBrand(brand model.PaymentMethodBrand) error {
 	switch brand {
-	case entity.PaymentMethodBrandAmex,
-		entity.PaymentMethodBrandMastercard,
-		entity.PaymentMethodBrandVisa:
+	case model.PaymentMethodBrandAmex,
+		model.PaymentMethodBrandMastercard,
+		model.PaymentMethodBrandVisa:
 		return nil
 	default:
 		return fmt.Errorf(
 			"brand must be: %s, %s, %s",
-			entity.PaymentMethodBrandAmex,
-			entity.PaymentMethodBrandMastercard,
-			entity.PaymentMethodBrandVisa,
+			model.PaymentMethodBrandAmex,
+			model.PaymentMethodBrandMastercard,
+			model.PaymentMethodBrandVisa,
 		)
 	}
 }

--- a/bean/internal/usecase/paymentmethod/validation_test.go
+++ b/bean/internal/usecase/paymentmethod/validation_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 func TestValidateLabel(t *testing.T) {
@@ -43,10 +43,10 @@ func TestValidateLast4(t *testing.T) {
 
 func TestValidateBrand(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		tests := []entity.PaymentMethodBrand{
-			entity.PaymentMethodBrandAmex,
-			entity.PaymentMethodBrandMastercard,
-			entity.PaymentMethodBrandVisa,
+		tests := []model.PaymentMethodBrand{
+			model.PaymentMethodBrandAmex,
+			model.PaymentMethodBrandMastercard,
+			model.PaymentMethodBrandVisa,
 		}
 
 		for _, test := range tests {

--- a/bean/internal/usecase/subscription/subscription.go
+++ b/bean/internal/usecase/subscription/subscription.go
@@ -3,7 +3,7 @@ package subscription
 import (
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 
 	"harvest/bean/internal/usecase/interfaces"
 )
@@ -20,8 +20,8 @@ func (u *UseCase) Create(
 	provider string,
 	amount int,
 	interval int,
-	period entity.SubscriptionPeriod,
-) (*entity.Subscription, error) {
+	period model.SubscriptionPeriod,
+) (*model.Subscription, error) {
 	if err := validateLabel(label); err != nil {
 		return nil, fmt.Errorf("invalid label: %w", err)
 	}

--- a/bean/internal/usecase/subscription/validation.go
+++ b/bean/internal/usecase/subscription/validation.go
@@ -3,7 +3,7 @@ package subscription
 import (
 	"fmt"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 func validateLabel(label string) error {
@@ -38,20 +38,20 @@ func validateInterval(interval int) error {
 	return nil
 }
 
-func validatePeriod(period entity.SubscriptionPeriod) error {
+func validatePeriod(period model.SubscriptionPeriod) error {
 	switch period {
-	case entity.SubscriptionPeriodDaily,
-		entity.SubscriptionPeriodWeekly,
-		entity.SubscriptionPeriodMonthly,
-		entity.SubscriptionPeriodYearly:
+	case model.SubscriptionPeriodDaily,
+		model.SubscriptionPeriodWeekly,
+		model.SubscriptionPeriodMonthly,
+		model.SubscriptionPeriodYearly:
 		return nil
 	default:
 		return fmt.Errorf(
 			"period must be: %s, %s, %s, %s",
-			entity.SubscriptionPeriodDaily,
-			entity.SubscriptionPeriodWeekly,
-			entity.SubscriptionPeriodMonthly,
-			entity.SubscriptionPeriodYearly,
+			model.SubscriptionPeriodDaily,
+			model.SubscriptionPeriodWeekly,
+			model.SubscriptionPeriodMonthly,
+			model.SubscriptionPeriodYearly,
 		)
 	}
 }

--- a/bean/internal/usecase/subscription/validation_test.go
+++ b/bean/internal/usecase/subscription/validation_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"harvest/bean/internal/entity"
+	"harvest/bean/internal/entity/model"
 )
 
 func TestValidateLabel(t *testing.T) {
@@ -69,11 +69,11 @@ func TestValidateInterval(t *testing.T) {
 
 func TestValidatePeriod(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		tests := []entity.SubscriptionPeriod{
-			entity.SubscriptionPeriodDaily,
-			entity.SubscriptionPeriodWeekly,
-			entity.SubscriptionPeriodMonthly,
-			entity.SubscriptionPeriodYearly,
+		tests := []model.SubscriptionPeriod{
+			model.SubscriptionPeriodDaily,
+			model.SubscriptionPeriodWeekly,
+			model.SubscriptionPeriodMonthly,
+			model.SubscriptionPeriodYearly,
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
Separates entities between models and viewmodels

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. `dc exec -e INTEGRATIONS=1 bean go test ./...`
4. Visit the `/`, `/get-started`, and `/cards` pages