### PR TITLE
bean: Fix multiple loading of scripts

### DIFF
--- a/bean/internal/driver/template/paymentmethods.html
+++ b/bean/internal/driver/template/paymentmethods.html
@@ -26,17 +26,19 @@
 
 <div class="section">
   {{ range .PaymentMethods }}
-  {{ template "card-content" . }}
+  {{ template "paymentmethod-container" . }}
   {{ end }}
 </div>
+
+{{ template "scripts" . }}
 {{ end }}
 
-{{ define "card-content" }}
-<div class="card-content">
+{{ define "paymentmethod-container" }}
+<div class="pm-container">
   <br /><br />
-  <details id="card-{{ .ID }}">
+  <details id="pm-{{ .ID }}">
     <summary>
-      {{ template "card-summary" . }}
+      {{ template "paymentmethod" . }}
     </summary>
 
     <br />
@@ -74,11 +76,9 @@
   </details>
   <br /><br />
 </div>
-
-{{ template "scripts" . }}
 {{ end }}
 
-{{ define "card-summary" }}
+{{ define "paymentmethod" }}
 <h4>{{ .Label }}</h4>
 <br /><br />
 <p>
@@ -138,11 +138,11 @@ hr {
   opacity: 0.4;
 }
 
-.card-content {
+.pm-container {
   position: relative;
 }
 
-.card-content:nth-of-type(odd)::before {
+.pm-container:nth-of-type(odd)::before {
   content: "";
 
   background-color: #f9f9f9;
@@ -175,34 +175,37 @@ hr {
 
 {{ define "scripts" }}
 <script>
-  // remembers if details are open or closed
+  // remembers if payment methods are open
 
   document.addEventListener("DOMContentLoaded", function (event) {
-    const details = document.querySelectorAll("details");
+    if (!localStorage) return;
 
-    details.forEach(function (detail) {
-      const key = "details-" + detail.id;
+    document
+      .querySelectorAll("details")
+      .forEach(function (detail) {
+        const key = "open-" + detail.id;
+        if (localStorage.getItem(key)) detail.open = true;
 
-      var open = localStorage.getItem(key);
-      if (open === "true") detail.open = true;
-
-      detail.addEventListener("toggle", function (event) {
-        localStorage.setItem(key, event.target.open);
+        detail.addEventListener("toggle", function (event) {
+          if (event.target.open) localStorage.setItem(key, true);
+          else localStorage.removeItem(key);
+        });
       });
-    });
-  });
+  }, { once: true });
 </script>
 <script>
   // maintains scroll position on page reload
 
   document.addEventListener("DOMContentLoaded", function (event) {
+    if (!localStorage) return;
+
     const scrollpos = localStorage.getItem("scrollpos");
 
     if (scrollpos) window.scrollTo(0, scrollpos);
-  });
+  }, { once: true });
 
   window.addEventListener("beforeunload", function (event) {
     localStorage.setItem("scrollpos", window.scrollY);
-  });
+  }, { once: true });
 </script>
 {{ end }}


### PR DESCRIPTION
Scripts was accidentally loaded inside `{{ range }}`. Moved outside.

Renames `card` -> `pm`

Adds once on the event listeners that should run only once

Testing instructions:
1. `dc up bean`
2. [`/cards`](http://localhost:8080/cards)
3. Open a card or two
4. Refresh the page
5. Ensure they are still opened
6. Ensure the scroll position is maintained