### PR TITLE
bean: Add delete paymentmethod template

### DIFF
--- a/bean/internal/driver/template/home.html
+++ b/bean/internal/driver/template/home.html
@@ -26,151 +26,37 @@
 
 <div class="section">
   {{ range .PaymentMethods }}
-  {{ template "paymentmethod-container" . }}
+  {{ template "paymentmethod-item" . }}
   {{ end }}
 </div>
 
 {{ template "scripts" . }}
 {{ end }}
 
-{{ define "paymentmethod-container" }}
-<div class="pm-container">
-  <br /><br />
-  <details id="pm-{{ .ID }}">
-    <summary>
-      {{ template "paymentmethod" . }}
-    </summary>
+{{ define "paymentmethod-item-actions" }}
+<div>
+  <p class="actionbar">
+    <a href="/cards/del?id={{ .ID }}">Delete card</a>
+  </p>
+</div>
 
-    <br />
+<br />
 
-    <div>
-      <p class="actionbar">
-        <a href="/todo">Delete card</a>
-      </p>
-    </div>
-
-    <br />
-
-    <div>
-      <p class="actionbar">
-        <a href="/todo">Add a new subscription</a>
-      </p>
-    </div>
-
-    <br />
-
-    <ul>
-      {{ if .Subscriptions }}
-      {{ range .Subscriptions }}
-      <hr /><br />
-      {{ template "subscription" . }}
-      <br />
-      {{ end }}
-      {{ else }}
-      <li class="subscription">
-        <hr /><br />
-        <p><em>No subscriptions</em></p>
-        <br />
-      {{ end }}
-    </ul>
-  </details>
-  <br /><br />
+<div>
+  <p class="actionbar">
+    <a href="/todo">Add a new subscription</a>
+  </p>
 </div>
 {{ end }}
 
-{{ define "paymentmethod" }}
-<h4>{{ .Label }}</h4>
-<br /><br />
-<p>
-  {{ .Last4 }}
+{{ define "subscription-item-actions" }}
+<p class="actionbar">
+  {{ if .Provider }}
+  <a target="_blank" href="{{ .Provider }}">Unsubscribe</a>
   &nbsp;·&nbsp;
-  {{ .ExpMonth }} / {{ .ExpYear }}
-  &nbsp;·&nbsp;
-  {{ .Brand }}
-</p>
-<p>
-  {{ .MonthlyEstimate }} monthly
-  &nbsp;·&nbsp;
-  {{ .YearlyEstimate }} yearly
-</p>
-{{ end }}
-
-{{ define "subscription" }}
-<li id="sub-{{ .ID }}">
-  {{ if .Label }}
-  <p><strong>{{ .Label }}</strong></p>
   {{ end }}
-  <p>
-    {{ .Amount }} &nbsp;·&nbsp; {{ .Frequency }}
-  </p>
-  <p class="actionbar">
-    {{ if .Provider }}
-    <a target="_blank" href="{{ .Provider }}">Unsubscribe</a>
-    &nbsp;·&nbsp;
-    {{ end }}
-    <a href="/todo">Delete</a>
-  </p>
-</li>
-{{ end }}
-
-{{ define "styles" }}
-<style>
-summary > h1,
-summary > h2,
-summary > h3,
-summary > h4,
-summary > h5 {
-  display: inline;
-
-  margin-left: 0.5em;
-
-  cursor: pointer;
-}
-
-ul {
-  list-style: none;
-
-  padding: 0;
-  margin: 0;
-}
-
-hr {
-  opacity: 0.4;
-}
-
-.pm-container {
-  position: relative;
-}
-
-.pm-container:nth-of-type(odd)::before {
-  content: "";
-
-  background-color: #f9f9f9;
-
-  width: 100vw;
-  height: 100%;
-
-  position: absolute;
-  z-index: -1;
-
-  top: 0;
-  /*
-    * The left value is calculated as follows.
-    * 
-    * We know the container width is min(100%, 36em).
-    * 
-    * Thus, we know the area outside the container.
-    * That is 100vw - min(100%, 36em).
-    * 
-    * But that area is to the left and right of the container.
-    * The container is centered, so they are equal. 
-    * So, we split it in half.
-    * 
-    * Then, we subtract that from 0rem to get the negative value.
-    */
-  left: calc(0rem - calc((100vw - min(100%, 36em)) / 2));
-}
-</style>
+  <a href="/todo">Delete</a>
+</p>
 {{ end }}
 
 {{ define "scripts" }}

--- a/bean/internal/driver/template/layout/base.html
+++ b/bean/internal/driver/template/layout/base.html
@@ -145,6 +145,51 @@
         padding: 0;
       }
 
+      summary > h1,
+      summary > h2,
+      summary > h3,
+      summary > h4,
+      summary > h5 {
+        display: inline;
+
+        margin-left: 0.5em;
+
+        cursor: pointer;
+      }
+
+      ul {
+        list-style: none;
+
+        padding: 0;
+        margin: 0;
+      }
+
+      hr {
+        opacity: 0.4;
+      }
+
+      nav {
+        font-size: 0.9em;
+        font-weight: bold;
+      }
+
+      footer {
+        font-size: 0.9rem;
+        font-weight: bold;
+
+        color: #063437;
+      }
+
+      header h1,
+      header h6,
+      footer p {
+        margin: 0;
+      }
+
+      header h6 {
+        font-weight: normal;
+      }
+
       .hidden {
         display: none;
       }
@@ -167,15 +212,6 @@
         margin-bottom: 5rem;
       }
 
-      .header h6 {
-        font-weight: normal;
-      }
-
-      .navbar {
-        font-size: 0.9em;
-        font-weight: bold;
-      }
-
       .actionbar {
         font-size: 0.9em;
       }
@@ -189,32 +225,52 @@
         display: inline-block;
       }
 
-      .footer {
-        font-size: 0.9rem;
-        font-weight: bold;
-
-        color: #063437;
+      .pm-container {
+        position: relative;
       }
 
-      .header h1,
-      .header h6,
-      .footer p {
-        margin: 0;
+      .pm-container:nth-of-type(odd)::before {
+        content: "";
+
+        background-color: #f9f9f9;
+
+        width: 100vw;
+        height: 100%;
+
+        position: absolute;
+        z-index: -1;
+
+        top: 0;
+        /*
+          * The left value is calculated as follows.
+          * 
+          * We know the container width is min(100%, 36em).
+          * 
+          * Thus, we know the area outside the container.
+          * That is 100vw - min(100%, 36em).
+          * 
+          * But that area is to the left and right of the container.
+          * The container is centered, so they are equal. 
+          * So, we split it in half.
+          * 
+          * Then, we subtract that from 0rem to get the negative value.
+          */
+        left: calc(0rem - calc((100vw - min(100%, 36em)) / 2));
       }
     </style>
   </head>
   <body>
     <div class="container">
-      <div class="section header">
+      <header class="section">
         <div class="subsection">
           <h1>bean</h1>
           <h6>/biːn/</h6>
         </div>
 
-        <div class="subsection navbar">{{ template "navbar" . }}</div>
-      </div>
+        <nav class="subsection">{{ template "navbar" . }}</nav>
+      </header>
       <div class="section content">{{ template "content" . }}</div>
-      <div class="section footer">
+      <footer class="section">
         <p>
           <a target="_blank" href="https://whatis277.com">277</a>
           &nbsp;·&nbsp;
@@ -224,7 +280,7 @@
             >GitHub</a
           >
         </p>
-      </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/bean/internal/driver/template/paymentmethod/delete.html
+++ b/bean/internal/driver/template/paymentmethod/delete.html
@@ -1,0 +1,55 @@
+{{ define "navbar" }}
+<a target="_blank" href="https://todo-stripe-link">Subscription</a>
+&nbsp;·&nbsp;
+<a href="/logout">Logout</a>
+{{ end }}
+
+{{ define "content" }}
+<div class="section">
+  <div class="subsection">
+    <h4>Delete card</h4>
+
+    <br />
+
+    <p>
+      Are you sure you want to delete this card?
+      <br />
+      It will remove all subscriptions associated with it.
+    </p>
+
+    <p>This action cannot be undone.</p>
+  </div>
+
+  <div class="subsection">
+    {{ template "paymentmethod-item" .PaymentMethod }}
+  </div>
+
+  <div class="subsection">
+    <form name="new" method="post">
+      <input
+        type="hidden"
+        name="csrf"
+        value="todo"
+      />
+
+      <input
+        type="hidden"
+        name="id"
+        value="{{ .PaymentMethod.ID }}"
+      />
+
+      <br />
+      <input type="submit" value="Delete card" />
+    </form>
+
+    <br /><br />
+
+    <p class="actionbar">
+      <a href="/home">Cancel</a>
+    </p>
+  </div>
+</div>
+{{ end }}
+
+{{ define "paymentmethod-item-actions" }}{{ end }}
+{{ define "subscription-item-actions" }}{{ end }}

--- a/bean/internal/driver/template/paymentmethod/item.html
+++ b/bean/internal/driver/template/paymentmethod/item.html
@@ -1,0 +1,49 @@
+{{ define "paymentmethod-item" }}
+<div class="pm-container">
+  <br /><br />
+  <details id="pm-{{ .ID }}">
+    <summary>
+      {{ template "paymentmethod-summary" . }}
+    </summary>
+
+    <br />
+
+    {{ template "paymentmethod-item-actions" . }}
+
+    <br />
+
+    <ul>
+      {{ if .Subscriptions }}
+      {{ range .Subscriptions }}
+      <hr /><br />
+      {{ template "subscription-item" . }}
+      <br />
+      {{ end }}
+      {{ else }}
+      <li class="subscription">
+        <hr /><br />
+        <p><em>No subscriptions</em></p>
+        <br />
+      {{ end }}
+    </ul>
+  </details>
+  <br /><br />
+</div>
+{{ end }}
+
+{{ define "paymentmethod-summary" }}
+<h4>{{ .Label }}</h4>
+<br /><br />
+<p>
+  {{ .Last4 }}
+  &nbsp;·&nbsp;
+  {{ .ExpMonth }} / {{ .ExpYear }}
+  &nbsp;·&nbsp;
+  {{ .Brand }}
+</p>
+<p>
+  {{ .MonthlyEstimate }} monthly
+  &nbsp;·&nbsp;
+  {{ .YearlyEstimate }} yearly
+</p>
+{{ end }}

--- a/bean/internal/driver/template/paymentmethod/item.html
+++ b/bean/internal/driver/template/paymentmethod/item.html
@@ -20,10 +20,11 @@
       <br />
       {{ end }}
       {{ else }}
-      <li class="subscription">
+      <li>
         <hr /><br />
         <p><em>No subscriptions</em></p>
         <br />
+      </li>
       {{ end }}
     </ul>
   </details>

--- a/bean/internal/driver/template/paymentmethod/item.html
+++ b/bean/internal/driver/template/paymentmethod/item.html
@@ -20,11 +20,11 @@
       <br />
       {{ end }}
       {{ else }}
+      <hr /><br />
       <li>
-        <hr /><br />
         <p><em>No subscriptions</em></p>
-        <br />
       </li>
+      <br />
       {{ end }}
     </ul>
   </details>

--- a/bean/internal/driver/template/subscription/item.html
+++ b/bean/internal/driver/template/subscription/item.html
@@ -1,0 +1,11 @@
+{{ define "subscription-item" }}
+<li id="sub-{{ .ID }}">
+  {{ if .Label }}
+  <p><strong>{{ .Label }}</strong></p>
+  {{ end }}
+  <p>
+    {{ .Amount }} &nbsp;·&nbsp; {{ .Frequency }}
+  </p>
+  {{ template "subscription-item-actions" . }}
+</li>
+{{ end }}

--- a/bean/internal/driver/template/template.go
+++ b/bean/internal/driver/template/template.go
@@ -5,7 +5,7 @@ import (
 )
 
 //go:embed *.html layout/*.html
-//go:embed paymentmethod/*.html
+//go:embed paymentmethod/*.html subscription/*.html
 var FS embed.FS
 
 const (
@@ -25,11 +25,19 @@ var (
 
 	HomeTemplate = []string{
 		baseTemplate,
+		"subscription/item.html",
+		"paymentmethod/item.html",
 		"home.html",
 	}
 
 	CreatePaymentMethodTemplate = []string{
 		baseTemplate,
 		"paymentmethod/create.html",
+	}
+	DeletePaymentMethodTemplate = []string{
+		baseTemplate,
+		"subscription/item.html",
+		"paymentmethod/item.html",
+		"paymentmethod/delete.html",
 	}
 )


### PR DESCRIPTION
Delete payment method template

Moves things around to:
- re-use payment methods
- re-use subscriptions
- re-use styles
- use nav, header, footer tags

No testing needed
