### PR TITLE
bean: Add create sub scaffold

### DIFF
--- a/bean/internal/adapter/handler/subscription/create.go
+++ b/bean/internal/adapter/handler/subscription/create.go
@@ -1,0 +1,46 @@
+package subscription
+
+import (
+	"fmt"
+	"net/http"
+
+	"harvest/bean/internal/entity/viewmodel"
+
+	"harvest/bean/internal/usecase/subscription"
+
+	"harvest/bean/internal/adapter/interfaces"
+)
+
+type createHandler struct {
+	subscriptions subscription.UseCase
+
+	view interfaces.CreateSubscriptionView
+}
+
+func newCreateHandler(
+	sub subscription.UseCase,
+	view interfaces.CreateSubscriptionView,
+) http.Handler {
+	return &createHandler{
+		subscriptions: sub,
+		view:          view,
+	}
+}
+
+func (h *createHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		h.render(w, &viewmodel.CreateSubscriptionViewData{})
+		return
+	}
+
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	fmt.Fprintf(w, "Method not allowed")
+}
+
+func (h *createHandler) render(w http.ResponseWriter, data *viewmodel.CreateSubscriptionViewData) {
+	err := h.view.Render(w, data)
+	if err != nil {
+		fmt.Fprintf(w, "Error: %v", err)
+		return
+	}
+}

--- a/bean/internal/adapter/handler/subscription/subscription.go
+++ b/bean/internal/adapter/handler/subscription/subscription.go
@@ -1,0 +1,24 @@
+package subscription
+
+import (
+	"net/http"
+
+	"harvest/bean/internal/usecase/subscription"
+
+	"harvest/bean/internal/adapter/interfaces"
+)
+
+type crudHandler struct {
+	Create http.Handler
+	Delete http.Handler
+}
+
+func New(
+	sub subscription.UseCase,
+	createView interfaces.CreateSubscriptionView,
+) crudHandler {
+	return crudHandler{
+		Create: newCreateHandler(sub, createView),
+		Delete: nil,
+	}
+}

--- a/bean/internal/adapter/interfaces/interfaces.go
+++ b/bean/internal/adapter/interfaces/interfaces.go
@@ -18,3 +18,5 @@ type HomeView View[viewmodel.HomeViewData]
 
 type CreatePaymentMethodView View[viewmodel.CreatePaymentMethodViewData]
 type DeletePaymentMethodView View[viewmodel.DeletePaymentMethodViewData]
+
+type CreateSubscriptionView View[viewmodel.CreateSubscriptionViewData]

--- a/bean/internal/driver/template/home.html
+++ b/bean/internal/driver/template/home.html
@@ -42,7 +42,7 @@
 
 <div>
   <p class="actionbar">
-    <a href="/todo">Add a new subscription</a>
+    <a href="/subs/new?pm={{ .ID }}">Add a new subscription</a>
   </p>
 </div>
 {{ end }}

--- a/bean/internal/driver/template/subscription/create.html
+++ b/bean/internal/driver/template/subscription/create.html
@@ -1,0 +1,9 @@
+{{ define "navbar" }}
+<a target="_blank" href="https://todo-stripe-link">Subscription</a>
+&nbsp;·&nbsp;
+<a href="/logout">Logout</a>
+{{ end }}
+
+{{ define "content" }}
+todo
+{{ end }}

--- a/bean/internal/driver/template/template.go
+++ b/bean/internal/driver/template/template.go
@@ -40,4 +40,9 @@ var (
 		"paymentmethod/item.html",
 		"paymentmethod/delete.html",
 	}
+
+	CreateSubscriptionTemplate = []string{
+		baseTemplate,
+		"subscription/create.html",
+	}
 )

--- a/bean/internal/driver/view/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/view/paymentmethod/paymentmethod.go
@@ -1,4 +1,4 @@
-package login
+package paymentmethod
 
 import (
 	"harvest/bean/internal/entity/viewmodel"

--- a/bean/internal/driver/view/subscription/subscription.go
+++ b/bean/internal/driver/view/subscription/subscription.go
@@ -1,4 +1,4 @@
-package home
+package subscription
 
 import (
 	"harvest/bean/internal/entity/viewmodel"
@@ -6,4 +6,4 @@ import (
 	"harvest/bean/internal/driver/view"
 )
 
-var New = view.New[viewmodel.HomeViewData]
+var NewCreate = view.New[viewmodel.CreateSubscriptionViewData]

--- a/bean/internal/entity/viewmodel/viewmodel.go
+++ b/bean/internal/entity/viewmodel/viewmodel.go
@@ -1,5 +1,35 @@
 package viewmodel
 
+// --- View Models ---
+
+// --- View Models --- Payment Method ---
+
+type PaymentMethod struct {
+	ID string
+
+	Label    string
+	Last4    string
+	Brand    string
+	ExpMonth int
+	ExpYear  int
+
+	MonthlyEstimate string
+	YearlyEstimate  string
+
+	Subscriptions []Subscription
+}
+
+// --- View Models --- Subscription ---
+
+type Subscription struct {
+	ID string
+
+	Label     string
+	Provider  string
+	Amount    string
+	Frequency string
+}
+
 // --- View Data ---
 
 type ViewData interface{}
@@ -23,30 +53,6 @@ type HomeViewData struct {
 	YearlyEstimate  string
 }
 
-type PaymentMethod struct {
-	ID string
-
-	Label    string
-	Last4    string
-	Brand    string
-	ExpMonth int
-	ExpYear  int
-
-	MonthlyEstimate string
-	YearlyEstimate  string
-
-	Subscriptions []Subscription
-}
-
-type Subscription struct {
-	ID string
-
-	Label     string
-	Provider  string
-	Amount    string
-	Frequency string
-}
-
 // --- View Data --- Payment Method ---
 
 type CreatePaymentMethodViewData struct {
@@ -66,3 +72,7 @@ type CreatePaymentMethodForm struct {
 	ExpMonth int
 	ExpYear  int
 }
+
+// --- View Data --- Subscription ---
+
+type CreateSubscriptionViewData struct{}


### PR DESCRIPTION
Setup needed to create smaller PRs for the template and handler

Just creates the route, view model, view

Adds a basic todo template and basic handler

Testing instructions:
1. `dc up bean`
2. [`/home`](http://localhost:8080/home)
3. Add a new subscription to a card
4. Ensure you see a "todo" page