### PR TITLE
bean: Add create sub handler

### DIFF
--- a/bean/internal/adapter/handler/subscription/create.go
+++ b/bean/internal/adapter/handler/subscription/create.go
@@ -3,7 +3,9 @@ package subscription
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
+	"harvest/bean/internal/entity/model"
 	"harvest/bean/internal/entity/viewmodel"
 
 	"harvest/bean/internal/usecase/subscription"
@@ -33,8 +35,37 @@ func (h *createHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Method == http.MethodPost {
+		h.post(w, r)
+		return
+	}
+
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	fmt.Fprintf(w, "Method not allowed")
+}
+
+func (h *createHandler) post(w http.ResponseWriter, r *http.Request) {
+	form := getFormData(r)
+
+	_, err := h.subscriptions.Create(
+		"10000000-0000-0000-0000-000000000001",
+		form.PaymentMethodID,
+		form.Label,
+		form.Provider,
+		getAmountInCents(form.Amount),
+		form.Interval,
+		model.SubscriptionPeriod(form.Period),
+	)
+
+	if err != nil {
+		h.render(w, &viewmodel.CreateSubscriptionViewData{
+			Error: err.Error(),
+			Form:  form,
+		})
+		return
+	}
+
+	http.Redirect(w, r, "/home", http.StatusSeeOther)
 }
 
 func (h *createHandler) render(w http.ResponseWriter, data *viewmodel.CreateSubscriptionViewData) {
@@ -43,4 +74,42 @@ func (h *createHandler) render(w http.ResponseWriter, data *viewmodel.CreateSubs
 		fmt.Fprintf(w, "Error: %v", err)
 		return
 	}
+}
+
+func getFormData(r *http.Request) viewmodel.CreateSubscriptionForm {
+	formData := viewmodel.CreateSubscriptionForm{}
+
+	if pmID := r.FormValue("pm"); pmID != "" {
+		formData.PaymentMethodID = pmID
+	}
+
+	if label := r.FormValue("label"); label != "" {
+		formData.Label = label
+	}
+
+	if provider := r.FormValue("provider"); provider != "" {
+		formData.Provider = provider
+	}
+
+	if amount := r.FormValue("amount"); amount != "" {
+		amount, _ := strconv.ParseFloat(amount, 32)
+
+		formData.Amount = float32(amount)
+	}
+
+	if interval := r.FormValue("interval"); interval != "" {
+		interval, _ := strconv.Atoi(interval)
+
+		formData.Interval = interval
+	}
+
+	if period := r.FormValue("period"); period != "" {
+		formData.Period = period
+	}
+
+	return formData
+}
+
+func getAmountInCents(amount float32) int {
+	return int(amount * 100)
 }

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -121,10 +121,6 @@ func (ds *dataSource) FindByID(userID string, id string) (*model.PaymentMethodWi
 		}
 	}
 
-	if method.ID == "" {
-		return nil, nil
-	}
-
 	return &model.PaymentMethodWithSubscriptions{
 		PaymentMethod: method,
 		Subscriptions: subs,

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -121,6 +121,10 @@ func (ds *dataSource) FindByID(userID string, id string) (*model.PaymentMethodWi
 		}
 	}
 
+	if method.ID == "" {
+		return nil, nil
+	}
+
 	return &model.PaymentMethodWithSubscriptions{
 		PaymentMethod: method,
 		Subscriptions: subs,

--- a/bean/internal/driver/template/subscription/create.html
+++ b/bean/internal/driver/template/subscription/create.html
@@ -74,6 +74,7 @@
         type="number"
         name="interval"
         min="1"
+        max="365"
         required
         {{ if .Form.Interval }}
         value="{{ .Form.Interval }}"

--- a/bean/internal/entity/viewmodel/viewmodel.go
+++ b/bean/internal/entity/viewmodel/viewmodel.go
@@ -86,7 +86,7 @@ type CreateSubscriptionForm struct {
 
 	Label    string
 	Provider string
-	Amount   string
-	Interval string
+	Amount   float32
+	Interval int
 	Period   string
 }

--- a/bean/internal/usecase/subscription/validation.go
+++ b/bean/internal/usecase/subscription/validation.go
@@ -35,6 +35,10 @@ func validateInterval(interval int) error {
 		return fmt.Errorf("interval must be greater than 0")
 	}
 
+	if interval > 365 {
+		return fmt.Errorf("interval must be less than 366")
+	}
+
 	return nil
 }
 

--- a/bean/internal/usecase/subscription/validation_test.go
+++ b/bean/internal/usecase/subscription/validation_test.go
@@ -64,6 +64,10 @@ func TestValidateInterval(t *testing.T) {
 		if err := validateInterval(0); err == nil {
 			t.Error("expected error, got nil")
 		}
+
+		if err := validateInterval(366); err == nil {
+			t.Error("expected error, got nil")
+		}
 	})
 }
 


### PR DESCRIPTION
Handles creation of subs

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. `dc exec -e INTEGRATION=1 bean go test ./...`
4. Ensure the validation for subs passes
5. [`/home`](http://localhost:8080/home)
6. Click add new sub for one of the cards
7. Modify the pm UUID in the URL
8. Set "Every" to 3 years
9. Submit the form
10. ~~Ensure you get a payment method not found error~~ You should get an SQL error (this will be fixed in a follow-up PR)
11. Ensure "year" and "3" persist
12. Modify the value for "year" to a wrong value
13. Ensure you get a message telling you the accepted values
14. Go back [`/home`](http://localhost:8080/home)
15. Ensure no new subs were created
16. Add a new subscription 
17. Fill the form correctly now 
18. Ensure the subscription is added on [`/home`](http://localhost:8080/home)