### PR TITLE
bean: Add delete sub handler

### DIFF
--- a/bean/internal/adapter/handler/paymentmethod/delete.go
+++ b/bean/internal/adapter/handler/paymentmethod/delete.go
@@ -58,8 +58,9 @@ func (h *deleteHandler) get(w http.ResponseWriter, r *http.Request) {
 		"10000000-0000-0000-0000-000000000001",
 		pmID,
 	)
-	if err != nil {
+	if err != nil || pm == nil {
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
+		return
 	}
 
 	estimates := h.estimator.GetEstimates(pm.Subscriptions)

--- a/bean/internal/adapter/handler/subscription/delete.go
+++ b/bean/internal/adapter/handler/subscription/delete.go
@@ -54,7 +54,7 @@ func (h *deleteHandler) get(w http.ResponseWriter, r *http.Request) {
 		"10000000-0000-0000-0000-000000000001",
 		subID,
 	)
-	if err != nil {
+	if err != nil || sub == nil {
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 		return
 	}
@@ -65,6 +65,17 @@ func (h *deleteHandler) get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *deleteHandler) post(w http.ResponseWriter, r *http.Request) {
+	subID := r.FormValue("id")
+	if subID == "" {
+		http.Redirect(w, r, "/home", http.StatusSeeOther)
+		return
+	}
+
+	h.subscriptions.Delete(
+		"10000000-0000-0000-0000-000000000001",
+		subID,
+	)
+
 	http.Redirect(w, r, "/home", http.StatusSeeOther)
 }
 


### PR DESCRIPTION
Delete subs on post request

Also adds redirection if fetched sub or pm is null

Testing instructions:
1. `dc up bean`
2. [`/home`](http://localhost:8080/home)
3. Try to delete a subscription
4. Ensure it deletes successfully
5. Try to delete another subscription
6. Modify the UUID to something that doesn't exist
7. Ensure you're redirected back home
8. Do the same with a card as with step 6
9. Ensure you're redirected back home