### PR TITLE
bean: Fix estimator not using interval

### DIFF
--- a/bean/internal/usecase/estimator/utils.go
+++ b/bean/internal/usecase/estimator/utils.go
@@ -9,50 +9,50 @@ func getSubscriptionEstimates(sub *model.Subscription) *model.Estimates {
 
 	switch sub.Period {
 	case model.SubscriptionPeriodDaily:
-		e = getEstimatesFromDaily(sub.Amount, sub.Interval)
+		e = getEstimatesFromDaily(sub.Amount)
 	case model.SubscriptionPeriodWeekly:
-		e = getEstimatesFromWeekly(sub.Amount, sub.Interval)
+		e = getEstimatesFromWeekly(sub.Amount)
 	case model.SubscriptionPeriodMonthly:
-		e = getEstimatesFromMonthly(sub.Amount, sub.Interval)
+		e = getEstimatesFromMonthly(sub.Amount)
 	case model.SubscriptionPeriodYearly:
-		e = getEstimatesFromYearly(sub.Amount, sub.Interval)
+		e = getEstimatesFromYearly(sub.Amount)
 	}
 
 	return e
 }
 
-func getEstimatesFromDaily(amount int, interval int) *model.Estimates {
+func getEstimatesFromDaily(amount int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / interval,
-		Weekly:  (amount * 7) / interval,
-		Monthly: (amount * 30) / interval,
-		Yearly:  (amount * 365) / interval,
+		Daily:   amount,
+		Weekly:  amount * 7,
+		Monthly: amount * 30,
+		Yearly:  amount * 365,
 	}
 }
 
-func getEstimatesFromWeekly(amount int, interval int) *model.Estimates {
+func getEstimatesFromWeekly(amount int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / (7 * interval),
-		Weekly:  amount / interval,
-		Monthly: (amount * 4) / interval,
-		Yearly:  (amount * 52) / interval,
+		Daily:   amount / 7,
+		Weekly:  amount,
+		Monthly: amount * 4,
+		Yearly:  amount * 52,
 	}
 }
 
-func getEstimatesFromMonthly(amount int, interval int) *model.Estimates {
+func getEstimatesFromMonthly(amount int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / (30 * interval),
-		Weekly:  amount / (4 * interval),
-		Monthly: amount / interval,
-		Yearly:  (amount * 12) / interval,
+		Daily:   amount / 30,
+		Weekly:  amount / 4,
+		Monthly: amount,
+		Yearly:  amount * 12,
 	}
 }
 
-func getEstimatesFromYearly(amount int, interval int) *model.Estimates {
+func getEstimatesFromYearly(amount int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / (365 * interval),
-		Weekly:  amount / (52 * interval),
-		Monthly: amount / (12 * interval),
-		Yearly:  amount / interval,
+		Daily:   amount / 365,
+		Weekly:  amount / 52,
+		Monthly: amount / 12,
+		Yearly:  amount,
 	}
 }

--- a/bean/internal/usecase/estimator/utils.go
+++ b/bean/internal/usecase/estimator/utils.go
@@ -9,50 +9,50 @@ func getSubscriptionEstimates(sub *model.Subscription) *model.Estimates {
 
 	switch sub.Period {
 	case model.SubscriptionPeriodDaily:
-		e = getEstimatesFromDaily(sub.Amount)
+		e = getEstimatesFromDaily(sub.Amount, sub.Interval)
 	case model.SubscriptionPeriodWeekly:
-		e = getEstimatesFromWeekly(sub.Amount)
+		e = getEstimatesFromWeekly(sub.Amount, sub.Interval)
 	case model.SubscriptionPeriodMonthly:
-		e = getEstimatesFromMonthly(sub.Amount)
+		e = getEstimatesFromMonthly(sub.Amount, sub.Interval)
 	case model.SubscriptionPeriodYearly:
-		e = getEstimatesFromYearly(sub.Amount)
+		e = getEstimatesFromYearly(sub.Amount, sub.Interval)
 	}
 
 	return e
 }
 
-func getEstimatesFromDaily(amount int) *model.Estimates {
+func getEstimatesFromDaily(amount int, interval int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount,
-		Weekly:  amount * 7,
-		Monthly: amount * 30,
-		Yearly:  amount * 365,
+		Daily:   amount / interval,
+		Weekly:  (amount * 7) / interval,
+		Monthly: (amount * 30) / interval,
+		Yearly:  (amount * 365) / interval,
 	}
 }
 
-func getEstimatesFromWeekly(amount int) *model.Estimates {
+func getEstimatesFromWeekly(amount int, interval int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / 7,
-		Weekly:  amount,
-		Monthly: amount * 4,
-		Yearly:  amount * 52,
+		Daily:   amount / (7 * interval),
+		Weekly:  amount / interval,
+		Monthly: (amount * 4) / interval,
+		Yearly:  (amount * 52) / interval,
 	}
 }
 
-func getEstimatesFromMonthly(amount int) *model.Estimates {
+func getEstimatesFromMonthly(amount int, interval int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / 30,
-		Weekly:  amount / 4,
-		Monthly: amount,
-		Yearly:  amount * 12,
+		Daily:   amount / (30 * interval),
+		Weekly:  amount / (4 * interval),
+		Monthly: amount / interval,
+		Yearly:  (amount * 12) / interval,
 	}
 }
 
-func getEstimatesFromYearly(amount int) *model.Estimates {
+func getEstimatesFromYearly(amount int, interval int) *model.Estimates {
 	return &model.Estimates{
-		Daily:   amount / 365,
-		Weekly:  amount / 52,
-		Monthly: amount / 12,
-		Yearly:  amount,
+		Daily:   amount / (365 * interval),
+		Weekly:  amount / (52 * interval),
+		Monthly: amount / (12 * interval),
+		Yearly:  amount / interval,
 	}
 }

--- a/bean/internal/usecase/estimator/utils.go
+++ b/bean/internal/usecase/estimator/utils.go
@@ -7,15 +7,17 @@ import (
 func getSubscriptionEstimates(sub *model.Subscription) *model.Estimates {
 	e := &model.Estimates{}
 
+	amount := sub.Amount / sub.Interval
+
 	switch sub.Period {
 	case model.SubscriptionPeriodDaily:
-		e = getEstimatesFromDaily(sub.Amount)
+		e = getEstimatesFromDaily(amount)
 	case model.SubscriptionPeriodWeekly:
-		e = getEstimatesFromWeekly(sub.Amount)
+		e = getEstimatesFromWeekly(amount)
 	case model.SubscriptionPeriodMonthly:
-		e = getEstimatesFromMonthly(sub.Amount)
+		e = getEstimatesFromMonthly(amount)
 	case model.SubscriptionPeriodYearly:
-		e = getEstimatesFromYearly(sub.Amount)
+		e = getEstimatesFromYearly(amount)
 	}
 
 	return e

--- a/bean/internal/usecase/estimator/utils_test.go
+++ b/bean/internal/usecase/estimator/utils_test.go
@@ -6,84 +6,84 @@ import (
 
 func TestGetEstimatesFromDaily(t *testing.T) {
 	amount := 100
-	estimates := getEstimatesFromDaily(amount)
+	estimates := getEstimatesFromDaily(amount, 2)
 
-	if estimates.Daily != amount {
-		t.Errorf("daily estimate should be %d, got %d", amount, estimates.Daily)
+	if estimates.Daily != amount/2 {
+		t.Errorf("daily estimate should be %d, got %d", amount/2, estimates.Daily)
 	}
 
-	if estimates.Weekly != amount*7 {
-		t.Errorf("weekly estimate should be %d, got %d", amount*7, estimates.Weekly)
+	if estimates.Weekly != (amount*7)/2 {
+		t.Errorf("weekly estimate should be %d, got %d", (amount*7)/2, estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount*30 {
-		t.Errorf("monthly estimate should be %d, got %d", amount*30, estimates.Monthly)
+	if estimates.Monthly != (amount*30)/2 {
+		t.Errorf("monthly estimate should be %d, got %d", (amount*30)/2, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount*365 {
-		t.Errorf("yearly estimate should be %d, got %d", amount*365, estimates.Yearly)
+	if estimates.Yearly != (amount*365)/2 {
+		t.Errorf("yearly estimate should be %d, got %d", (amount*365)/2, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromWeekly(t *testing.T) {
 	amount := 700
-	estimates := getEstimatesFromWeekly(amount)
+	estimates := getEstimatesFromWeekly(amount, 7)
 
-	if estimates.Daily != amount/7 {
-		t.Errorf("daily estimate should be %d, got %d", amount/7, estimates.Daily)
+	if estimates.Daily != amount/49 {
+		t.Errorf("daily estimate should be %d, got %d", amount/49, estimates.Daily)
 	}
 
-	if estimates.Weekly != amount {
-		t.Errorf("weekly estimate should be %d, got %d", amount, estimates.Weekly)
+	if estimates.Weekly != amount/7 {
+		t.Errorf("weekly estimate should be %d, got %d", amount/7, estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount*4 {
-		t.Errorf("monthly estimate should be %d, got %d", amount*4, estimates.Monthly)
+	if estimates.Monthly != amount*4/7 {
+		t.Errorf("monthly estimate should be %d, got %d", amount*4/7, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount*52 {
-		t.Errorf("yearly estimate should be %d, got %d", amount*52, estimates.Yearly)
+	if estimates.Yearly != amount*52/7 {
+		t.Errorf("yearly estimate should be %d, got %d", amount*52/7, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromMonthly(t *testing.T) {
 	amount := 2500
-	estimates := getEstimatesFromMonthly(amount)
+	estimates := getEstimatesFromMonthly(amount, 5)
 
-	if estimates.Daily != amount/30 {
-		t.Errorf("daily estimate should be %d, got %d", amount/30, estimates.Daily)
+	if estimates.Daily != amount/(30*5) {
+		t.Errorf("daily estimate should be %d, got %d", amount/(30*5), estimates.Daily)
 	}
 
-	if estimates.Weekly != amount/4 {
-		t.Errorf("weekly estimate should be %d, got %d", amount/4, estimates.Weekly)
+	if estimates.Weekly != amount/(4*5) {
+		t.Errorf("weekly estimate should be %d, got %d", amount/(4*5), estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount {
-		t.Errorf("monthly estimate should be %d, got %d", amount, estimates.Monthly)
+	if estimates.Monthly != amount/5 {
+		t.Errorf("monthly estimate should be %d, got %d", amount/5, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount*12 {
-		t.Errorf("yearly estimate should be %d, got %d", amount*12, estimates.Yearly)
+	if estimates.Yearly != amount*12/5 {
+		t.Errorf("yearly estimate should be %d, got %d", amount*12/5, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromYearly(t *testing.T) {
 	amount := 100000
-	estimates := getEstimatesFromYearly(amount)
+	estimates := getEstimatesFromYearly(amount, 2)
 
-	if estimates.Daily != amount/365 {
-		t.Errorf("daily estimate should be %d, got %d", amount/365, estimates.Daily)
+	if estimates.Daily != amount/(365*2) {
+		t.Errorf("daily estimate should be %d, got %d", amount/(365*2), estimates.Daily)
 	}
 
-	if estimates.Weekly != amount/52 {
-		t.Errorf("weekly estimate should be %d, got %d", amount/52, estimates.Weekly)
+	if estimates.Weekly != amount/(52*2) {
+		t.Errorf("weekly estimate should be %d, got %d", amount/(52*2), estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount/12 {
-		t.Errorf("monthly estimate should be %d, got %d", amount/12, estimates.Monthly)
+	if estimates.Monthly != amount/(12*2) {
+		t.Errorf("monthly estimate should be %d, got %d", amount/(12*2), estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount {
-		t.Errorf("yearly estimate should be %d, got %d", amount, estimates.Yearly)
+	if estimates.Yearly != amount/2 {
+		t.Errorf("yearly estimate should be %d, got %d", amount/2, estimates.Yearly)
 	}
 }

--- a/bean/internal/usecase/estimator/utils_test.go
+++ b/bean/internal/usecase/estimator/utils_test.go
@@ -6,84 +6,84 @@ import (
 
 func TestGetEstimatesFromDaily(t *testing.T) {
 	amount := 100
-	estimates := getEstimatesFromDaily(amount, 2)
+	estimates := getEstimatesFromDaily(amount)
 
-	if estimates.Daily != amount/2 {
-		t.Errorf("daily estimate should be %d, got %d", amount/2, estimates.Daily)
+	if estimates.Daily != amount {
+		t.Errorf("daily estimate should be %d, got %d", amount, estimates.Daily)
 	}
 
-	if estimates.Weekly != (amount*7)/2 {
-		t.Errorf("weekly estimate should be %d, got %d", (amount*7)/2, estimates.Weekly)
+	if estimates.Weekly != amount*7 {
+		t.Errorf("weekly estimate should be %d, got %d", amount*7, estimates.Weekly)
 	}
 
-	if estimates.Monthly != (amount*30)/2 {
-		t.Errorf("monthly estimate should be %d, got %d", (amount*30)/2, estimates.Monthly)
+	if estimates.Monthly != amount*30 {
+		t.Errorf("monthly estimate should be %d, got %d", amount*30, estimates.Monthly)
 	}
 
-	if estimates.Yearly != (amount*365)/2 {
-		t.Errorf("yearly estimate should be %d, got %d", (amount*365)/2, estimates.Yearly)
+	if estimates.Yearly != amount*365 {
+		t.Errorf("yearly estimate should be %d, got %d", amount*365, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromWeekly(t *testing.T) {
 	amount := 700
-	estimates := getEstimatesFromWeekly(amount, 7)
+	estimates := getEstimatesFromWeekly(amount)
 
-	if estimates.Daily != amount/49 {
-		t.Errorf("daily estimate should be %d, got %d", amount/49, estimates.Daily)
+	if estimates.Daily != amount/7 {
+		t.Errorf("daily estimate should be %d, got %d", amount/7, estimates.Daily)
 	}
 
-	if estimates.Weekly != amount/7 {
-		t.Errorf("weekly estimate should be %d, got %d", amount/7, estimates.Weekly)
+	if estimates.Weekly != amount {
+		t.Errorf("weekly estimate should be %d, got %d", amount, estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount*4/7 {
-		t.Errorf("monthly estimate should be %d, got %d", amount*4/7, estimates.Monthly)
+	if estimates.Monthly != amount*4 {
+		t.Errorf("monthly estimate should be %d, got %d", amount*4, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount*52/7 {
-		t.Errorf("yearly estimate should be %d, got %d", amount*52/7, estimates.Yearly)
+	if estimates.Yearly != amount*52 {
+		t.Errorf("yearly estimate should be %d, got %d", amount*52, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromMonthly(t *testing.T) {
 	amount := 2500
-	estimates := getEstimatesFromMonthly(amount, 5)
+	estimates := getEstimatesFromMonthly(amount)
 
-	if estimates.Daily != amount/(30*5) {
-		t.Errorf("daily estimate should be %d, got %d", amount/(30*5), estimates.Daily)
+	if estimates.Daily != amount/30 {
+		t.Errorf("daily estimate should be %d, got %d", amount/30, estimates.Daily)
 	}
 
-	if estimates.Weekly != amount/(4*5) {
-		t.Errorf("weekly estimate should be %d, got %d", amount/(4*5), estimates.Weekly)
+	if estimates.Weekly != amount/4 {
+		t.Errorf("weekly estimate should be %d, got %d", amount/4, estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount/5 {
-		t.Errorf("monthly estimate should be %d, got %d", amount/5, estimates.Monthly)
+	if estimates.Monthly != amount {
+		t.Errorf("monthly estimate should be %d, got %d", amount, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount*12/5 {
-		t.Errorf("yearly estimate should be %d, got %d", amount*12/5, estimates.Yearly)
+	if estimates.Yearly != amount*12 {
+		t.Errorf("yearly estimate should be %d, got %d", amount*12, estimates.Yearly)
 	}
 }
 
 func TestGetEstimatesFromYearly(t *testing.T) {
 	amount := 100000
-	estimates := getEstimatesFromYearly(amount, 2)
+	estimates := getEstimatesFromYearly(amount)
 
-	if estimates.Daily != amount/(365*2) {
-		t.Errorf("daily estimate should be %d, got %d", amount/(365*2), estimates.Daily)
+	if estimates.Daily != amount/365 {
+		t.Errorf("daily estimate should be %d, got %d", amount/365, estimates.Daily)
 	}
 
-	if estimates.Weekly != amount/(52*2) {
-		t.Errorf("weekly estimate should be %d, got %d", amount/(52*2), estimates.Weekly)
+	if estimates.Weekly != amount/52 {
+		t.Errorf("weekly estimate should be %d, got %d", amount/52, estimates.Weekly)
 	}
 
-	if estimates.Monthly != amount/(12*2) {
-		t.Errorf("monthly estimate should be %d, got %d", amount/(12*2), estimates.Monthly)
+	if estimates.Monthly != amount/12 {
+		t.Errorf("monthly estimate should be %d, got %d", amount/12, estimates.Monthly)
 	}
 
-	if estimates.Yearly != amount/2 {
-		t.Errorf("yearly estimate should be %d, got %d", amount/2, estimates.Yearly)
+	if estimates.Yearly != amount {
+		t.Errorf("yearly estimate should be %d, got %d", amount, estimates.Yearly)
 	}
 }


### PR DESCRIPTION
Estimator wasn't taking into account the interval

For example, a subscription for $20 every 2 months was calculated to:
* $20 monthly
* $240 yearly

Instead it should be:
* $10 monthly
* $120 yearly

Testing instructions:
1. `dc up bean`
2. `dc exec bean go test ./...`