### PR TITLE
bean: Add local smtp client

### DIFF
--- a/bean/README.md
+++ b/bean/README.md
@@ -10,6 +10,19 @@ A subscription tracker for the rest of us.
 ### Development
 
 * Bean: http://localhost:8080
+* SMTP: http://localhost:8025
+
+## Dependencies
+
+### Development
+
+* Postgres: Database
+* MailHog: SMTP server
+
+### Production
+
+* Postgres: Database
+* Postmark: SMTP server
 
 ## Guide
 

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -4,6 +4,11 @@ DB_HOST=postgres
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
+# smtp server
+SMTP_HOST=smtp
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
 # tern for migration
 TERN_CONFIG=./bean/config/.migration.tern.conf
 TERN_MIGRATIONS=./bean/internal/driver/migration

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -26,6 +26,26 @@ func New() (*Env, error) {
 		return nil, err
 	}
 
+	smtpHost, err := lookup("SMTP_HOST")
+	if err != nil {
+		return nil, err
+	}
+
+	smtpPort, err := lookup("SMTP_PORT")
+	if err != nil {
+		return nil, err
+	}
+
+	smtpUsername, err := lookup("SMTP_USERNAME")
+	if err != nil {
+		return nil, err
+	}
+
+	smtpPassword, err := lookup("SMTP_PASSWORD")
+	if err != nil {
+		return nil, err
+	}
+
 	return &Env{
 		DB: &DB{
 			Name:     dbName,
@@ -33,6 +53,12 @@ func New() (*Env, error) {
 			Port:     dbPort,
 			Username: dbUsername,
 			Password: dbPassword,
+		},
+		SMTP: &SMTP{
+			Host:     smtpHost,
+			Port:     smtpPort,
+			Username: smtpUsername,
+			Password: smtpPassword,
 		},
 	}, nil
 }

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -12,6 +12,11 @@ func TestEnv(t *testing.T) {
 	os.Setenv("DB_USERNAME", "db_username")
 	os.Setenv("DB_PASSWORD", "db_password")
 
+	os.Setenv("SMTP_HOST", "smtp_host")
+	os.Setenv("SMTP_PORT", "smtp_port")
+	os.Setenv("SMTP_USERNAME", "smtp_username")
+	os.Setenv("SMTP_PASSWORD", "smtp_password")
+
 	env, err := New()
 
 	if err != nil {
@@ -36,5 +41,21 @@ func TestEnv(t *testing.T) {
 
 	if env.DB.Password != "db_password" {
 		t.Errorf("expected: %s, got: %s", "db_password", env.DB.Password)
+	}
+
+	if env.SMTP.Host != "smtp_host" {
+		t.Errorf("expected: %s, got: %s", "smtp_host", env.SMTP.Host)
+	}
+
+	if env.SMTP.Port != "smtp_port" {
+		t.Errorf("expected: %s, got: %s", "smtp_port", env.SMTP.Port)
+	}
+
+	if env.SMTP.Username != "smtp_username" {
+		t.Errorf("expected: %s, got: %s", "smtp_username", env.SMTP.Username)
+	}
+
+	if env.SMTP.Password != "smtp_password" {
+		t.Errorf("expected: %s, got: %s", "smtp_password", env.SMTP.Password)
 	}
 }

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -1,11 +1,19 @@
 package env
 
 type Env struct {
-	DB *DB
+	DB   *DB
+	SMTP *SMTP
 }
 
 type DB struct {
 	Name     string
+	Host     string
+	Port     string
+	Username string
+	Password string
+}
+
+type SMTP struct {
 	Host     string
 	Port     string
 	Username string

--- a/bean/internal/driver/smtp/smtp.go
+++ b/bean/internal/driver/smtp/smtp.go
@@ -1,0 +1,54 @@
+package smtp
+
+import (
+	"fmt"
+	"net/smtp"
+
+	"harvest/bean/internal/usecase/interfaces"
+)
+
+type client struct {
+	addr string
+	auth smtp.Auth
+}
+
+type Config struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+}
+
+func New(cfg *Config) interfaces.Emailer {
+	return &client{
+		addr: fmt.Sprintf("%s:%s", cfg.Host, cfg.Port),
+		auth: smtp.CRAMMD5Auth(cfg.Username, cfg.Password),
+	}
+}
+
+func (c *client) Send(
+	from string,
+	to string,
+	subject string,
+	body string,
+) error {
+	msg := fmt.Sprintf(
+		("From: %s" +
+			"\r\n" +
+			"To: %s" +
+			"\r\n" +
+			"Subject: %s" +
+			"\r\n" +
+			"\r\n" +
+			"%s" +
+			"\r\n"),
+		from, to, subject, body,
+	)
+
+	err := smtp.SendMail(c.addr, c.auth, from, []string{to}, []byte(msg))
+	if err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	return nil
+}

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -63,5 +63,5 @@ type Hasher interface {
 }
 
 type Emailer interface {
-	Send(email string, subject string, body string) error
+	Send(from string, to string, subject string, body string) error
 }

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -11,6 +11,8 @@ import (
 )
 
 type UseCase struct {
+	sender string
+
 	users  interfaces.UserDataSource
 	tokens interfaces.LoginTokenDataSource
 
@@ -40,6 +42,7 @@ func (u *UseCase) SendEmail(email string) error {
 	}
 
 	if err = u.emailer.Send(
+		u.sender,
 		email,
 		"Login to Bean",
 		fmt.Sprintf(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      smtp:
+        condition: service_started
 
   pear:
     <<: *common
@@ -28,9 +30,19 @@ services:
       - ./pear/html:/usr/share/nginx/html
       - ./pear/config/nginx.conf:/etc/nginx/conf.d/default.conf
 
+  smtp:
+    <<: *common
+    image: mailhog/mailhog:latest
+    restart: always
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    volumes:
+      - mailhog-data:/var/lib/mailhog
+
   postgres:
     <<: *common
-    image: postgres:16.1
+    image: postgres:latest
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -48,3 +60,4 @@ services:
 
 volumes:
   postgres-data:
+  mailhog-data:


### PR DESCRIPTION
SMTP client that will allow testing locally

For production, we'll be using Postmark

Testing instructions:
1. Apply the following patch to the code

```diff
diff --git a/bean/cmd/server/main.go b/bean/cmd/server/main.go
index d0d71e4..7dc29b2 100644
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
        subscriptionDS "harvest/bean/internal/driver/datasource/subscription"
        "harvest/bean/internal/driver/postgres"
        "harvest/bean/internal/driver/server"
+       "harvest/bean/internal/driver/smtp"
        "harvest/bean/internal/driver/template"
        homeVD "harvest/bean/internal/driver/view/home"
        landingVD "harvest/bean/internal/driver/view/landing"
@@ -49,6 +50,25 @@ func main() {
        }
        defer db.Close()
 
+       emailer := smtp.New(&smtp.Config{
+               Host:     env.SMTP.Host,
+               Port:     env.SMTP.Port,
+               Username: env.SMTP.Username,
+               Password: env.SMTP.Password,
+       })
+
+       err = emailer.Send(
+               "support@whatisbean.com",
+               "277@hey.com",
+               "Hello, Bean!",
+               "This is a test.",
+       )
+       if err != nil {
+               panic(
+                       fmt.Errorf("error sending email: %v", err),
+               )
+       }
+
        estimator := estimatorUC.UseCase{}
 
        paymentMethodRepo := paymentMethodDS.New(db)

```

2. `dc down --volumes`

3. `dc up bean`

4. Check (localhost:8025)[http://localhost:8025/]

5. Ensure you see "Hello, Bean!"

<img width="1059" alt="image" src="https://github.com/whatis277/harvest/assets/5631091/7a954bc6-e714-4d15-aac6-db6ae199c449">
