### PR TITLE
bean: Add passwordless auth login handler

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	subscriptionUC "harvest/bean/internal/usecase/subscription"
 
 	envAdapter "harvest/bean/internal/adapter/env"
+	authHandler "harvest/bean/internal/adapter/handler/auth"
 	homeHandler "harvest/bean/internal/adapter/handler/home"
 	landingHandler "harvest/bean/internal/adapter/handler/landing"
 	loginHandler "harvest/bean/internal/adapter/handler/login"
@@ -137,6 +138,8 @@ func main() {
 	s := server.New()
 
 	s.Route("/", landingHandler.New(landingView))
+
+	s.Route("/auth", authHandler.New(passwordlessAuth))
 	s.Route("/get-started", loginHandler.New(
 		passwordlessAuth,
 		loginView,

--- a/bean/internal/adapter/handler/auth/auth.go
+++ b/bean/internal/adapter/handler/auth/auth.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"net/http"
+
+	"harvest/bean/internal/usecase/passwordless"
+)
+
+type handler struct {
+	auth passwordless.UseCase
+}
+
+func New(
+	auth passwordless.UseCase,
+) http.Handler {
+	return &handler{
+		auth: auth,
+	}
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		h.get(w, r)
+		return
+	}
+
+	http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+}
+
+func (h *handler) get(w http.ResponseWriter, r *http.Request) {
+	id, password := r.FormValue("i"), r.FormValue("p")
+	if id == "" || password == "" {
+		http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+		return
+	}
+
+	_, err := h.auth.Login(id, password)
+	if err != nil {
+		http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, "/home", http.StatusSeeOther)
+}

--- a/bean/internal/adapter/handler/login/login.go
+++ b/bean/internal/adapter/handler/login/login.go
@@ -1,4 +1,4 @@
-package landing
+package login
 
 import (
 	"fmt"
@@ -38,7 +38,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	http.Redirect(w, r, "/home", http.StatusSeeOther)
 }
 
 func (h *handler) render(w http.ResponseWriter, r *http.Request, data *viewmodel.LoginViewData) {

--- a/bean/internal/driver/bcrypt/bcrypt_test.go
+++ b/bean/internal/driver/bcrypt/bcrypt_test.go
@@ -20,3 +20,22 @@ func TestHasher(t *testing.T) {
 		t.Error("hash length is not 60")
 	}
 }
+
+func TestCompare(t *testing.T) {
+	hasher := New()
+
+	hashed, err := hasher.Hash("test")
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	err = hasher.Compare("test", hashed)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	err = hasher.Compare(hashed, "wrong")
+	if err == nil {
+		t.Fatal("error: expected error, got nil")
+	}
+}

--- a/bean/internal/driver/bcrypt/bcrypt_test.go
+++ b/bean/internal/driver/bcrypt/bcrypt_test.go
@@ -34,7 +34,7 @@ func TestCompare(t *testing.T) {
 		t.Fatalf("error: %s", err)
 	}
 
-	err = hasher.Compare(hashed, "wrong")
+	err = hasher.Compare("wrong", hashed)
 	if err == nil {
 		t.Fatal("error: expected error, got nil")
 	}

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -59,7 +59,11 @@ func (u *UseCase) Login(id string, password string) (*model.User, error) {
 		return nil, fmt.Errorf("failed to find token: %w", err)
 	}
 
-	if err := u.Hasher.Compare(token.HashedToken, password); err != nil {
+	if token == nil {
+		return nil, fmt.Errorf("token not found")
+	}
+
+	if err := u.Hasher.Compare(password, token.HashedToken); err != nil {
 		return nil, fmt.Errorf("failed to compare password: %w", err)
 	}
 
@@ -97,7 +101,7 @@ func buildEmailBody(tokenID, password string) string {
 			"\r\n\r\n" +
 			"Use this link to login to Bean:" +
 			"\r\n" +
-			"https://localhost:8080/login?i=%s&p=%s" +
+			"http://localhost:8080/auth?i=%s&p=%s" +
 			"\r\n\r\n" +
 			"This link will expire in 10 minutes." +
 			"\r\n" +


### PR DESCRIPTION
Authenticates the user's login token through the handler

Does not create a session at the moment, this will be handled separately

Testing instructions:
1. `dc up bean`
2. `dc exec bean go test harvest/bean/internal/driver/bcrypt`
3. Ensure it succeeds
4. http://localhost:8080/get-started
5. Enter an email address
6. Go to localhost:8025
7. Click the login link
8. Ensure you're redirected to http://localhost:8080/home
9. Go to localhost:8025
10. Click the login link again
11. Ensure you're redirected to http://localhost:8080/get-started
12. `dc exec postgres psql -U postgres bean_test -c 'select * from login_tokens;'`
13. Ensure there's no login token for the email you entered
14. `dc exec postgres psql -U postgres bean_test -c 'select * from users;'`
15. Ensure there's a user for the email you entered
16. Repeat steps 4, 5, 6, and 7 again
17. Repeat step 14
18. Ensure there are no errors logging in
19. Ensure no duplicate user is created