### PR TITLE
bean: Add base url to env

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -76,14 +76,17 @@ func main() {
 		PaymentMethods: paymentMethodRepo,
 	}
 
+	authRoute := "/auth"
 	tokenRepo := tokenDS.New(db)
 	userRepo := userDS.New(db)
 	passwordlessAuth := passwordless.UseCase{
-		Sender:  "Bean <support@whatisbean.com>",
-		Users:   userRepo,
-		Tokens:  tokenRepo,
-		Hasher:  hasher,
-		Emailer: emailer,
+		Sender:    "Bean <support@whatisbean.com>",
+		BaseURL:   env.BaseURL,
+		AuthRoute: authRoute,
+		Users:     userRepo,
+		Tokens:    tokenRepo,
+		Hasher:    hasher,
+		Emailer:   emailer,
 	}
 
 	landingView, err := landingVD.New(template.FS, template.LandingTemplate)
@@ -139,7 +142,7 @@ func main() {
 
 	s.Route("/", landingHandler.New(landingView))
 
-	s.Route("/auth", authHandler.New(passwordlessAuth))
+	s.Route(authRoute, authHandler.New(passwordlessAuth))
 	s.Route("/get-started", loginHandler.New(
 		passwordlessAuth,
 		loginView,

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -1,3 +1,5 @@
+# general
+BASE_URL=http://localhost:8080
 # database
 DB_NAME=bean_test
 DB_HOST=postgres

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -1,6 +1,11 @@
 package env
 
 func New() (*Env, error) {
+	baseURL, err := lookup("BASE_URL")
+	if err != nil {
+		return nil, err
+	}
+
 	dbName, err := lookup("DB_NAME")
 	if err != nil {
 		return nil, err
@@ -47,6 +52,7 @@ func New() (*Env, error) {
 	}
 
 	return &Env{
+		BaseURL: baseURL,
 		DB: &DB{
 			Name:     dbName,
 			Host:     dbHost,

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestEnv(t *testing.T) {
+	os.Setenv("BASE_URL", "base_url")
+
 	os.Setenv("DB_NAME", "db_name")
 	os.Setenv("DB_HOST", "db_host")
 	os.Setenv("DB_PORT", "db_port")
@@ -21,6 +23,10 @@ func TestEnv(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("error: %s", err)
+	}
+
+	if env.BaseURL != "base_url" {
+		t.Errorf("expected: %s, got: %s", "base_url", env.BaseURL)
 	}
 
 	if env.DB.Name != "db_name" {

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -1,6 +1,8 @@
 package env
 
 type Env struct {
+	BaseURL string
+
 	DB   *DB
 	SMTP *SMTP
 }

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -11,7 +11,9 @@ import (
 )
 
 type UseCase struct {
-	Sender string
+	Sender    string
+	BaseURL   string
+	AuthRoute string
 
 	Users  interfaces.UserDataSource
 	Tokens interfaces.LoginTokenDataSource
@@ -45,7 +47,7 @@ func (u *UseCase) SendEmail(email string) error {
 		u.Sender,
 		email,
 		"Login",
-		buildEmailBody(token.ID, password),
+		u.buildEmailBody(token.ID, password),
 	); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
@@ -95,19 +97,25 @@ func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
 	return user, nil
 }
 
-func buildEmailBody(tokenID, password string) string {
+func (u *UseCase) buildEmailBody(tokenID, password string) string {
+	authUrl := fmt.Sprintf(
+		"%s%s?i=%s&p=%s",
+		u.BaseURL, u.AuthRoute,
+		tokenID, password,
+	)
+
 	return fmt.Sprintf(
 		("Hello." +
 			"\r\n\r\n" +
 			"Use this link to login to Bean:" +
 			"\r\n" +
-			"http://localhost:8080/auth?i=%s&p=%s" +
+			"%s" +
 			"\r\n\r\n" +
 			"This link will expire in 10 minutes." +
 			"\r\n" +
 			"If you did not request this, don't worry." +
 			"\r\n\r\n" +
 			"Cheers."),
-		tokenID, password,
+		authUrl,
 	)
 }


### PR DESCRIPTION
Includes base url in env variables

Also uses the base URL in the passwordless email

Testing instructions:
1. `dc up bean`
2. `dc exec bean go test harvest/bean/internal/adapter/env`
3. [`/get-started`](http://localhost:8080/get-started)
4. Enter an email address 
5. Open [Mailhog](http://localhost:8025)
6. Ensure the auth URL is valid
7. Open the auth URL and ensure you're redirected to `/home`