### PR TITLE
bean: Add cache redis driver

### DIFF
--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -6,6 +6,11 @@ DB_HOST=postgres
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
+# cache
+CACHE_HOST=redis
+CACHE_PORT=6379
+CACHE_USERNAME=default
+CACHE_PASSWORD=
 # smtp server
 SMTP_HOST=smtp
 SMTP_PORT=1025

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -31,6 +31,26 @@ func New() (*Env, error) {
 		return nil, err
 	}
 
+	cacheHost, err := lookup("CACHE_HOST")
+	if err != nil {
+		return nil, err
+	}
+
+	cachePort, err := lookup("CACHE_PORT")
+	if err != nil {
+		return nil, err
+	}
+
+	cacheUsername, err := lookup("CACHE_USERNAME")
+	if err != nil {
+		return nil, err
+	}
+
+	cachePassword, err := lookup("CACHE_PASSWORD")
+	if err != nil {
+		return nil, err
+	}
+
 	smtpHost, err := lookup("SMTP_HOST")
 	if err != nil {
 		return nil, err
@@ -59,6 +79,12 @@ func New() (*Env, error) {
 			Port:     dbPort,
 			Username: dbUsername,
 			Password: dbPassword,
+		},
+		Cache: &Cache{
+			Host:     cacheHost,
+			Port:     cachePort,
+			Username: cacheUsername,
+			Password: cachePassword,
 		},
 		SMTP: &SMTP{
 			Host:     smtpHost,

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -14,6 +14,11 @@ func TestEnv(t *testing.T) {
 	os.Setenv("DB_USERNAME", "db_username")
 	os.Setenv("DB_PASSWORD", "db_password")
 
+	os.Setenv("CACHE_HOST", "cache_host")
+	os.Setenv("CACHE_PORT", "cache_port")
+	os.Setenv("CACHE_USERNAME", "cache_username")
+	os.Setenv("CACHE_PASSWORD", "cache_password")
+
 	os.Setenv("SMTP_HOST", "smtp_host")
 	os.Setenv("SMTP_PORT", "smtp_port")
 	os.Setenv("SMTP_USERNAME", "smtp_username")
@@ -47,6 +52,22 @@ func TestEnv(t *testing.T) {
 
 	if env.DB.Password != "db_password" {
 		t.Errorf("expected: %s, got: %s", "db_password", env.DB.Password)
+	}
+
+	if env.Cache.Host != "cache_host" {
+		t.Errorf("expected: %s, got: %s", "cache_host", env.Cache.Host)
+	}
+
+	if env.Cache.Port != "cache_port" {
+		t.Errorf("expected: %s, got: %s", "cache_port", env.Cache.Port)
+	}
+
+	if env.Cache.Username != "cache_username" {
+		t.Errorf("expected: %s, got: %s", "cache_username", env.Cache.Username)
+	}
+
+	if env.Cache.Password != "cache_password" {
+		t.Errorf("expected: %s, got: %s", "cache_password", env.Cache.Password)
 	}
 
 	if env.SMTP.Host != "smtp_host" {

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -3,12 +3,20 @@ package env
 type Env struct {
 	BaseURL string
 
-	DB   *DB
-	SMTP *SMTP
+	DB    *DB
+	Cache *Cache
+	SMTP  *SMTP
 }
 
 type DB struct {
 	Name     string
+	Host     string
+	Port     string
+	Username string
+	Password string
+}
+
+type Cache struct {
 	Host     string
 	Port     string
 	Username string

--- a/bean/internal/driver/postgres/postgres.go
+++ b/bean/internal/driver/postgres/postgres.go
@@ -27,6 +27,6 @@ func New(builder *DSNBuilder) (*DB, error) {
 	}, nil
 }
 
-func (ds *DB) Close() {
-	ds.Pool.Close()
+func (db *DB) Close() {
+	db.Pool.Close()
 }

--- a/bean/internal/driver/redis/redis.go
+++ b/bean/internal/driver/redis/redis.go
@@ -1,0 +1,48 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type Options struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+}
+
+type Cache struct {
+	Client *redis.Client
+}
+
+func New(opts *Options) (*Cache, error) {
+	addr := fmt.Sprintf("%s:%s", opts.Host, opts.Port)
+
+	client := redis.NewClient(
+		&redis.Options{
+			Addr:     addr,
+			Username: opts.Username,
+			Password: opts.Password,
+		},
+	)
+	if client == nil {
+		return nil, errors.New("error creating redis client")
+	}
+
+	err := client.Ping(context.Background()).Err()
+	if err != nil {
+		return nil, errors.New("error pinging redis: " + err.Error())
+	}
+
+	return &Cache{
+		Client: client,
+	}, nil
+}
+
+func (cache *Cache) Close() {
+	cache.Client.Close()
+}

--- a/bean/internal/driver/redis/redis_test.go
+++ b/bean/internal/driver/redis/redis_test.go
@@ -1,0 +1,31 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/whatis277/harvest/bean/internal/driver/redis/redistest"
+)
+
+func TestCache(t *testing.T) {
+	cache := redistest.CacheTest(t)
+
+	err := cache.Client.Ping(context.TODO()).Err()
+	if err != nil {
+		t.Fatalf("cache error: %s", err)
+	}
+
+	err = cache.Client.Set(context.Background(), "key", "value", 0).Err()
+	if err != nil {
+		t.Fatalf("cache error: %s", err)
+	}
+
+	val, err := cache.Client.Get(context.Background(), "key").Result()
+	if err != nil {
+		t.Fatalf("cache error: %s", err)
+	}
+
+	if val != "value" {
+		t.Fatalf("expected value to be 'value', got %s", val)
+	}
+}

--- a/bean/internal/driver/redis/redistest/redistest.go
+++ b/bean/internal/driver/redis/redistest/redistest.go
@@ -1,0 +1,33 @@
+package redistest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/whatis277/harvest/bean/internal/driver/redis"
+)
+
+func CacheTest(t *testing.T) *redis.Cache {
+	t.Helper()
+
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration test, set env var INTEGRATION=1")
+	}
+
+	cache, err := redis.New(&redis.Options{
+		Host:     "redis",
+		Port:     "6379",
+		Username: "default",
+		Password: "",
+	})
+
+	if err != nil {
+		t.Fatalf("cache error: %s", err)
+	}
+
+	t.Cleanup(func() {
+		cache.Close()
+	})
+
+	return cache
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
       smtp:
         condition: service_started
 
@@ -40,6 +42,20 @@ services:
     volumes:
       - mailhog-data:/var/lib/mailhog
 
+  redis:
+    <<: *common
+    image: redis:latest
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+
   postgres:
     <<: *common
     image: postgres:latest
@@ -60,4 +76,5 @@ services:
 
 volumes:
   postgres-data:
+  redis-data:
   mailhog-data:

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,15 @@ go 1.21.5
 
 require github.com/jackc/pgx/v5 v5.5.2 // direct [bean,]
 
+require github.com/redis/go-redis/v9 v9.4.0 // direct [bean,]
+
 require golang.org/x/crypto v0.18.0 // direct [bean,]
 
 require github.com/google/uuid v1.5.0 // direct [bean,]
 
 require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,14 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -13,6 +21,8 @@ github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.4.0 h1:Yzoz33UZw9I/mFhx4MNrB6Fk+XHO1VukNcCa1+lwyKk=
+github.com/redis/go-redis/v9 v9.4.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
We need a persistent cache for later

So redis it is

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/redis -v`
3. Ensure tests pass and aren't skipped