### PR TITLE
bean: Add session datasource

### DIFF
--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/whatis277/harvest/bean/internal/entity/model"
+
+  "github.com/whatis277/harvest/bean/internal/entity/model"
 
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 

--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/whatis277/harvest/bean/internal/entity/model"
+
+	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
+
+	"github.com/whatis277/harvest/bean/internal/driver/redis"
+)
+
+type dataSource struct {
+	cache *redis.Cache
+}
+
+func New(cache *redis.Cache) interfaces.SessionDataSource {
+	return &dataSource{
+		cache: cache,
+	}
+}
+
+func (ds *dataSource) Create(
+	userID string,
+	hashedToken string,
+	duration time.Duration,
+) (*model.Session, error) {
+	return ds.doCreate(userID, hashedToken, duration, 0)
+}
+
+func (ds *dataSource) doCreate(
+	userID string,
+	hashedToken string,
+	duration time.Duration,
+	attempts int,
+) (*model.Session, error) {
+	if attempts > 3 {
+		return nil, fmt.Errorf("failed to generate session: max attempts exceeded")
+	}
+
+	rand, err := uuid.NewRandom()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random session id: %w", err)
+	}
+
+	id := rand.String()
+
+	existing, err := ds.FindByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find existing session: %w", err)
+	}
+
+	if existing != nil {
+		return ds.doCreate(userID, hashedToken, duration, attempts+1)
+	}
+
+	session := &model.Session{
+		ID:          id,
+		UserID:      userID,
+		HashedToken: hashedToken,
+	}
+
+	err = ds.cache.Client.Set(context.Background(), id, session, duration).Err()
+	if err != nil {
+		return nil, fmt.Errorf("failed to set session in cache: %w", err)
+	}
+
+	return session, nil
+}
+
+func (ds *dataSource) FindByID(id string) (*model.Session, error) {
+	session := &model.Session{}
+
+	err := ds.cache.Client.Get(context.Background(), id).Scan(session)
+	if err == redis.ErrNoRows {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session from cache: %w", err)
+	}
+
+	return session, nil
+}
+
+func (ds *dataSource) Refresh(id string, duration time.Duration) error {
+	err := ds.cache.Client.Expire(context.Background(), id, duration).Err()
+	if err != nil {
+		return fmt.Errorf("failed to refresh session in cache: %w", err)
+	}
+
+	return nil
+}
+
+func (ds *dataSource) Delete(id string) error {
+	err := ds.cache.Client.Del(context.Background(), id).Err()
+	if err != nil {
+		return fmt.Errorf("failed to delete session from cache: %w", err)
+	}
+
+	return nil
+}

--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-  "github.com/whatis277/harvest/bean/internal/entity/model"
+	"github.com/whatis277/harvest/bean/internal/entity/model"
 
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -1,0 +1,170 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
+
+	"github.com/whatis277/harvest/bean/internal/driver/redis"
+	"github.com/whatis277/harvest/bean/internal/driver/redis/redistest"
+)
+
+func TestDataSource(t *testing.T) {
+	cache := redistest.CacheTest(t)
+	ds := New(cache)
+
+	t.Run("create", func(t *testing.T) {
+		create(t, ds, cache)
+	})
+
+	t.Run("find_by_id", func(t *testing.T) {
+		findById(t, ds)
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		refresh(t, ds, cache)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		delete(t, ds)
+	})
+}
+
+func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
+	t.Run("new_session", func(t *testing.T) {
+		session, err := ds.Create("action-create", "hashed-token", 10*time.Second)
+		if err != nil {
+			t.Fatalf("failed to create session: %s", err)
+		}
+
+		if session.ID == "" {
+			t.Error("expected session ID, got empty string")
+		}
+
+		if session.UserID != "action-create" {
+			t.Errorf("expected user ID: %s, got: %s", "action-create", session.UserID)
+		}
+
+		if session.HashedToken != "hashed-token" {
+			t.Errorf("expected hashed token: %s, got: %s", "hashed-token", session.HashedToken)
+		}
+
+		ttl := cache.Client.TTL(context.Background(), session.ID).Val()
+		if ttl != 10*time.Second {
+			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
+		}
+
+		if err = ds.Delete(session.ID); err != nil {
+			t.Fatalf("failed to cleanup session: %s", err)
+		}
+	})
+}
+
+func findById(t *testing.T, ds interfaces.SessionDataSource) {
+	t.Run("existing_session", func(t *testing.T) {
+		session, err := ds.Create("action-find", "hashed-token", 10*time.Second)
+		if err != nil {
+			t.Fatalf("failed to create session: %s", err)
+		}
+
+		session, err = ds.FindByID(session.ID)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %s", err)
+		}
+
+		if session == nil {
+			t.Fatalf("expected session, got nil")
+		}
+
+		if session.ID == "" {
+			t.Error("expected session ID, got empty string")
+		}
+
+		if session.UserID != "action-find" {
+			t.Errorf("expected user ID: %s, got: %s", "action-find", session.UserID)
+		}
+
+		if session.HashedToken != "hashed-token" {
+			t.Errorf("expected hashed token: %s, got: %s", "hashed-token", session.HashedToken)
+		}
+
+		if err = ds.Delete(session.ID); err != nil {
+			t.Fatalf("failed to cleanup session: %s", err)
+		}
+	})
+
+	t.Run("missing_session", func(t *testing.T) {
+		session, err := ds.FindByID("missing-id")
+		if err != nil {
+			t.Fatalf("expected nil error, got: %s", err)
+		}
+
+		if session != nil {
+			t.Errorf("expected nil session, got: %v", session)
+		}
+	})
+}
+
+func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
+	t.Run("existing_session", func(t *testing.T) {
+		session, err := ds.Create("action-refresh", "hashed-token", 10*time.Second)
+		if err != nil {
+			t.Fatalf("failed to create session: %s", err)
+		}
+
+		ttl := cache.Client.TTL(context.Background(), session.ID).Val()
+		if ttl != 10*time.Second {
+			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
+		}
+
+		err = ds.Refresh(session.ID, 20*time.Second)
+		if err != nil {
+			t.Fatalf("failed to refresh session: %s", err)
+		}
+
+		ttl = cache.Client.TTL(context.Background(), session.ID).Val()
+		if ttl != 20*time.Second {
+			t.Errorf("expected session to expire in: %s, got: %s", 20*time.Second, ttl)
+		}
+
+		if err = ds.Delete(session.ID); err != nil {
+			t.Fatalf("failed to delete session: %s", err)
+		}
+	})
+
+	t.Run("missing_session", func(t *testing.T) {
+		if err := ds.Refresh("missing-id", 20*time.Second); err != nil {
+			t.Fatalf("failed to refresh session: %s", err)
+		}
+	})
+}
+
+func delete(t *testing.T, ds interfaces.SessionDataSource) {
+	t.Run("existing_session", func(t *testing.T) {
+		session, err := ds.Create("action-delete", "hashed-token", 10*time.Second)
+		if err != nil {
+			t.Fatalf("failed to create session: %s", err)
+		}
+
+		if err = ds.Delete(session.ID); err != nil {
+			t.Fatalf("failed to delete session: %s", err)
+		}
+
+		session, err = ds.FindByID(session.ID)
+		if err != nil {
+			t.Fatalf("failed to find session: %s", err)
+		}
+
+		if session != nil {
+			t.Errorf("expected nil session, got: %v", session)
+		}
+	})
+
+	t.Run("missing_session", func(t *testing.T) {
+		if err := ds.Delete("missing-id"); err != nil {
+			t.Fatalf("failed to delete session: %s", err)
+		}
+	})
+}

--- a/bean/internal/driver/redis/errors.go
+++ b/bean/internal/driver/redis/errors.go
@@ -1,0 +1,9 @@
+package redis
+
+import (
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	ErrNoRows = redis.Nil
+)

--- a/bean/internal/entity/model/model.go
+++ b/bean/internal/entity/model/model.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -82,6 +83,25 @@ type LoginToken struct {
 
 	CreatedAt time.Time
 	ExpiresAt time.Time
+}
+
+// --- Cache ---
+
+// --- Cache --- Session ---
+
+type Session struct {
+	ID     string
+	UserID string
+
+	HashedToken string
+}
+
+func (s *Session) MarshalBinary() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *Session) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, s)
 }
 
 // --- Misc ---

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -1,6 +1,8 @@
 package interfaces
 
 import (
+	"time"
+
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
@@ -51,6 +53,16 @@ type LoginTokenDataSource interface {
 	Create(email string, hashedToken string) (*model.LoginToken, error)
 
 	FindUnexpired(id string) (*model.LoginToken, error)
+
+	Delete(id string) error
+}
+
+type SessionDataSource interface {
+	Create(userID string, hashedToken string, duration time.Duration) (*model.Session, error)
+
+	FindByID(id string) (*model.Session, error)
+
+	Refresh(id string, duration time.Duration) error
 
 	Delete(id string) error
 }


### PR DESCRIPTION
A session data source for cache client

Create, read, delete, and refresh methods

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/datasource/session -v`