### PR TITLE
bean: Add session model expires at

### DIFF
--- a/bean/internal/entity/model/model.go
+++ b/bean/internal/entity/model/model.go
@@ -94,6 +94,10 @@ type Session struct {
 	UserID string
 
 	HashedToken string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ExpiresAt time.Time
 }
 
 func (s *Session) MarshalBinary() ([]byte, error) {

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -62,7 +62,7 @@ type SessionDataSource interface {
 
 	FindByID(id string) (*model.Session, error)
 
-	Refresh(id string, duration time.Duration) error
+	Refresh(id string, duration time.Duration) (*model.Session, error)
 
 	Delete(id string) error
 }


### PR DESCRIPTION
Adds created at, updated at and expired at to the session model

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/datasource/session -v`
