### PR TITLE
bean: Add passwordless session creation

### DIFF
--- a/bean/internal/adapter/handler/auth/auth.go
+++ b/bean/internal/adapter/handler/auth/auth.go
@@ -41,13 +41,13 @@ func (h *handler) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sesssionBin, err := sessionToken.MarshalBinary()
+	sessionBin, err := sessionToken.MarshalBinary()
 	if err != nil {
 		http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 		return
 	}
 
-	sessionVal := base64.StdEncoding.EncodeToString([]byte(sesssionBin))
+	sessionVal := base64.StdEncoding.EncodeToString([]byte(sessionBin))
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
 		Value:    sessionVal,

--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
 	"github.com/whatis277/harvest/bean/internal/driver/redis"
+
+	"github.com/google/uuid"
 )
 
 type dataSource struct {

--- a/bean/internal/driver/redis/redis.go
+++ b/bean/internal/driver/redis/redis.go
@@ -8,7 +8,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-type Options struct {
+type Config struct {
 	Host     string
 	Port     string
 	Username string
@@ -19,14 +19,14 @@ type Cache struct {
 	Client *redis.Client
 }
 
-func New(opts *Options) (*Cache, error) {
-	addr := fmt.Sprintf("%s:%s", opts.Host, opts.Port)
+func New(cfg *Config) (*Cache, error) {
+	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
 
 	client := redis.NewClient(
 		&redis.Options{
 			Addr:     addr,
-			Username: opts.Username,
-			Password: opts.Password,
+			Username: cfg.Username,
+			Password: cfg.Password,
 		},
 	)
 	if client == nil {

--- a/bean/internal/driver/redis/redistest/redistest.go
+++ b/bean/internal/driver/redis/redistest/redistest.go
@@ -14,7 +14,7 @@ func CacheTest(t *testing.T) *redis.Cache {
 		t.Skip("skipping integration test, set env var INTEGRATION=1")
 	}
 
-	cache, err := redis.New(&redis.Options{
+	cache, err := redis.New(&redis.Config{
 		Host:     "redis",
 		Port:     "6379",
 		Username: "default",

--- a/bean/internal/entity/model/model.go
+++ b/bean/internal/entity/model/model.go
@@ -90,14 +90,14 @@ type LoginToken struct {
 // --- Cache --- Session ---
 
 type Session struct {
-	ID     string
-	UserID string
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
 
-	HashedToken string
+	HashedToken string `json:"hashed_token"`
 
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	ExpiresAt time.Time
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 func (s *Session) MarshalBinary() ([]byte, error) {
@@ -105,6 +105,26 @@ func (s *Session) MarshalBinary() ([]byte, error) {
 }
 
 func (s *Session) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, s)
+}
+
+// --- Cookie ---
+
+// --- Cookie --- Session Token ---
+
+type SessionToken struct {
+	ID string `json:"id"`
+
+	Token string `json:"token"`
+
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (s *SessionToken) MarshalBinary() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *SessionToken) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, s)
 }
 


### PR DESCRIPTION
Creates server-sided and client-sided sessions on passwordless login

The session will be used in a future PR

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test ./... -v`
3. Go to http://localhost:8080/get-started
4. Enter an email address and login
5. Go to http://localhost:8025/
6. Click on the link
7. Open the developer console -> Application -> Cookies
8. Copy the session value 
9. Decode it using base64 with `echo "<value>" | base64 --decode`
10. Ensure the token matches the `p` value from the login link
11. Ensure the expiration is 14 days in the future