### PR TITLE
bean: Fix auth session token cookie

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -28,13 +28,11 @@ func (c *Controller) Authorize() http.HandlerFunc {
 			return
 		}
 
-		cookie, err := createSessionCookie(sessionToken)
+		err = addSessionTokenCookie(w, sessionToken)
 		if err != nil {
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}
-
-		http.SetCookie(w, cookie)
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/auth/sessiontoken.go
+++ b/bean/internal/adapter/controller/auth/sessiontoken.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/whatis277/harvest/bean/internal/entity/model"
+)
+
+const sessionCookieName = "session"
+
+func getSessionToken(r *http.Request) (*model.SessionToken, error) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session token: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode session token: %w", err)
+	}
+
+	token := model.SessionToken{}
+	err = token.UnmarshalBinary(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session token: %w", err)
+	}
+
+	return &token, nil
+}
+
+func addSessionTokenCookie(w http.ResponseWriter, token *model.SessionToken) error {
+	json, err := token.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal session token: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(json))
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    encoded,
+		Expires:  token.ExpiresAt,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	return nil
+}
+
+func removeSessionTokenCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}


### PR DESCRIPTION
Adds `Path` to the cookie

Also moves creating, reading, and deleting the cookie to `auth/sessiontoken.go`

Testing instructions:
1. `dc up --build bean`
2. Visit http://localhost:8080/get-started
3. Clear cookies
4. Use any email to login 
5. Visit http://localhost:8025 for the login url
6. Use the URL
7. Check dev console cookies for "session"