### PR TITLE
bean: Add passwordless session usecases

### DIFF
--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -94,16 +94,16 @@ func (ds *dataSource) FindByID(id string) (*model.Session, error) {
 	return session, nil
 }
 
-func (ds *dataSource) Refresh(session *model.Session, duration time.Duration) (*model.Session, error) {
+func (ds *dataSource) Refresh(session *model.Session, duration time.Duration) error {
 	session.UpdatedAt = time.Now()
 	session.ExpiresAt = session.UpdatedAt.Add(duration)
 
 	err := ds.cache.Client.Set(context.Background(), session.ID, session, duration).Err()
 	if err != nil {
-		return nil, fmt.Errorf("failed to refresh session in cache: %w", err)
+		return fmt.Errorf("failed to refresh session in cache: %w", err)
 	}
 
-	return session, nil
+	return nil
 }
 
 func (ds *dataSource) Delete(id string) error {

--- a/bean/internal/driver/datasource/session/session.go
+++ b/bean/internal/driver/datasource/session/session.go
@@ -94,20 +94,11 @@ func (ds *dataSource) FindByID(id string) (*model.Session, error) {
 	return session, nil
 }
 
-func (ds *dataSource) Refresh(id string, duration time.Duration) (*model.Session, error) {
-	session, err := ds.FindByID(id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find session: %w", err)
-	}
-
-	if session == nil {
-		return nil, fmt.Errorf("failed to find session: session not found")
-	}
-
+func (ds *dataSource) Refresh(session *model.Session, duration time.Duration) (*model.Session, error) {
 	session.UpdatedAt = time.Now()
 	session.ExpiresAt = session.UpdatedAt.Add(duration)
 
-	err = ds.cache.Client.Set(context.Background(), id, session, duration).Err()
+	err := ds.cache.Client.Set(context.Background(), session.ID, session, duration).Err()
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh session in cache: %w", err)
 	}

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -141,7 +141,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
 
-		session, err = ds.Refresh(session.ID, 20*time.Second)
+		session, err = ds.Refresh(session, 20*time.Second)
 		if err != nil {
 			t.Fatalf("failed to refresh session: %s", err)
 		}
@@ -158,17 +158,6 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 
 		if err = ds.Delete(session.ID); err != nil {
 			t.Fatalf("failed to delete session: %s", err)
-		}
-	})
-
-	t.Run("missing_session", func(t *testing.T) {
-		session, err := ds.Refresh("missing-id", 20*time.Second)
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-
-		if session != nil {
-			t.Errorf("expected nil session, got: %v", session)
 		}
 	})
 }

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -141,7 +141,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
 
-		session, err = ds.Refresh(session, 20*time.Second)
+		err = ds.Refresh(session, 20*time.Second)
 		if err != nil {
 			t.Fatalf("failed to refresh session: %s", err)
 		}

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -62,7 +62,7 @@ type SessionDataSource interface {
 
 	FindByID(id string) (*model.Session, error)
 
-	Refresh(session *model.Session, duration time.Duration) (*model.Session, error)
+	Refresh(session *model.Session, duration time.Duration) error
 
 	Delete(id string) error
 }

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -62,7 +62,7 @@ type SessionDataSource interface {
 
 	FindByID(id string) (*model.Session, error)
 
-	Refresh(id string, duration time.Duration) (*model.Session, error)
+	Refresh(session *model.Session, duration time.Duration) (*model.Session, error)
 
 	Delete(id string) error
 }

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -105,7 +105,7 @@ func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session
 		return nil, fmt.Errorf("failed to compare session token: %w", err)
 	}
 
-	session, err = u.Sessions.Refresh(session, 14*24*time.Hour)
+	err = u.Sessions.Refresh(session, 14*24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh session: %w", err)
 	}

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -91,6 +91,49 @@ func (u *UseCase) Login(id string, password string) (*model.SessionToken, error)
 	return sessionToken, nil
 }
 
+func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session, error) {
+	session, err := u.Sessions.FindByID(sessionToken.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find session: %w", err)
+	}
+
+	if session == nil {
+		return nil, fmt.Errorf("session not found")
+	}
+
+	if err := u.Hasher.Compare(sessionToken.Token, session.HashedToken); err != nil {
+		return nil, fmt.Errorf("failed to compare session token: %w", err)
+	}
+
+	session, err = u.Sessions.Refresh(session, 14*24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh session: %w", err)
+	}
+
+	sessionToken.ExpiresAt = session.ExpiresAt
+
+	return session, nil
+}
+
+func (u *UseCase) Logout(sessionToken *model.SessionToken) error {
+	session, err := u.Sessions.FindByID(sessionToken.ID)
+	if err != nil {
+		return fmt.Errorf("failed to find session: %w", err)
+	}
+
+	if session == nil {
+		return fmt.Errorf("session not found")
+	}
+
+	if err := u.Hasher.Compare(sessionToken.Token, session.HashedToken); err != nil {
+		return fmt.Errorf("failed to compare session token: %w", err)
+	}
+
+	u.Sessions.Delete(session.ID)
+
+	return nil
+}
+
 func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
 	user, err := u.Users.FindByEmail(email)
 	if err != nil {


### PR DESCRIPTION
Adds authenticate and logout session use cases to passwordless

They both fetch the session using the session token
Then, validate the hash to ensure said user owns it

From there, authenticate refreshes the session 
Meanwhile, logout deletes the session

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/datasource/session`