### PR TITLE
bean: Add session authentication

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -186,12 +186,18 @@ func main() {
 
 	s := server.New()
 
+	// Unauthenticated routes
+
 	s.Route("GET /{$}", marketingController.LandingPage())
 
 	s.Route("GET /auth/{id}/{password}", authControler.Authorize())
 
 	s.Route("GET /get-started", authControler.LoginPage())
 	s.Route("POST /get-started", authControler.LoginForm())
+
+	// Authenticated routes
+
+	s.Use(authControler.Authenticate)
 
 	s.Route("GET /home", appController.HomePage())
 

--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/usecase/paymentmethod"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/controller/app/shared"
+	"github.com/whatis277/harvest/bean/internal/adapter/controller/auth"
 	"github.com/whatis277/harvest/bean/internal/adapter/interfaces"
 )
 
@@ -22,7 +23,9 @@ type Controller struct {
 
 func (c *Controller) HomePage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		methods, err := c.PaymentMethods.List("10000000-0000-0000-0000-000000000001")
+		session := auth.SessionFromContext(r.Context())
+
+		methods, err := c.PaymentMethods.List(session.UserID)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/adapter/controller/app/paymentmethod/create.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/create.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 	"github.com/whatis277/harvest/bean/internal/entity/viewmodel"
+
+	"github.com/whatis277/harvest/bean/internal/adapter/controller/auth"
 )
 
 func (c *Controller) CreatePage() http.HandlerFunc {
@@ -19,8 +21,10 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		form := getCreateFormData(r)
 
+		session := auth.SessionFromContext(r.Context())
+
 		_, err := c.PaymentMethods.Create(
-			"10000000-0000-0000-0000-000000000001",
+			session.UserID,
 			form.Label,
 			form.Last4,
 			model.PaymentMethodBrand(form.Brand),

--- a/bean/internal/adapter/controller/app/paymentmethod/delete.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/viewmodel"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/controller/app/shared"
+	"github.com/whatis277/harvest/bean/internal/adapter/controller/auth"
 )
 
 func (c *Controller) DeletePage() http.HandlerFunc {
@@ -17,10 +18,9 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 			return
 		}
 
-		pm, err := c.PaymentMethods.Get(
-			"10000000-0000-0000-0000-000000000001",
-			id,
-		)
+		session := auth.SessionFromContext(r.Context())
+
+		pm, err := c.PaymentMethods.Get(session.UserID, id)
 		if err != nil || pm == nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return
@@ -42,10 +42,9 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 			return
 		}
 
-		c.PaymentMethods.Delete(
-			"10000000-0000-0000-0000-000000000001",
-			id,
-		)
+		session := auth.SessionFromContext(r.Context())
+
+		c.PaymentMethods.Delete(session.UserID, id)
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/app/subscription/create.go
+++ b/bean/internal/adapter/controller/app/subscription/create.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 	"github.com/whatis277/harvest/bean/internal/entity/viewmodel"
+
+	"github.com/whatis277/harvest/bean/internal/adapter/controller/auth"
 )
 
 func (c *Controller) CreatePage() http.HandlerFunc {
@@ -25,8 +27,10 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		form := getCreateFormData(r)
 
+		session := auth.SessionFromContext(r.Context())
+
 		_, err := c.Subscriptions.Create(
-			"10000000-0000-0000-0000-000000000001",
+			session.UserID,
 			form.PaymentMethodID,
 			form.Label,
 			form.Provider,

--- a/bean/internal/adapter/controller/app/subscription/delete.go
+++ b/bean/internal/adapter/controller/app/subscription/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/viewmodel"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/controller/app/shared"
+	"github.com/whatis277/harvest/bean/internal/adapter/controller/auth"
 )
 
 func (c *Controller) DeletePage() http.HandlerFunc {
@@ -17,10 +18,9 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 			return
 		}
 
-		sub, err := c.Subscriptions.Get(
-			"10000000-0000-0000-0000-000000000001",
-			subID,
-		)
+		session := auth.SessionFromContext(r.Context())
+
+		sub, err := c.Subscriptions.Get(session.UserID, subID)
 		if err != nil || sub == nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return
@@ -40,10 +40,9 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 			return
 		}
 
-		c.Subscriptions.Delete(
-			"10000000-0000-0000-0000-000000000001",
-			subID,
-		)
+		session := auth.SessionFromContext(r.Context())
+
+		c.Subscriptions.Delete(session.UserID, subID)
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -32,6 +32,7 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 
 		err = addSessionTokenCookie(w, sessionToken)
 		if err != nil {
+			removeSessionTokenCookie(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}
@@ -58,6 +59,7 @@ func (c *Controller) Authorize() http.HandlerFunc {
 
 		err = addSessionTokenCookie(w, sessionToken)
 		if err != nil {
+			removeSessionTokenCookie(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -14,6 +14,34 @@ type Controller struct {
 	LoginView interfaces.LoginView
 }
 
+func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sessionToken, err := getSessionToken(r)
+		if err != nil || sessionToken == nil {
+			removeSessionTokenCookie(w)
+			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			return
+		}
+
+		session, err := c.Passwordless.Authenticate(sessionToken)
+		if err != nil || session == nil {
+			removeSessionTokenCookie(w)
+			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			return
+		}
+
+		err = addSessionTokenCookie(w, sessionToken)
+		if err != nil {
+			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			return
+		}
+
+		ctx := NewContextWithSession(r.Context(), session)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}
+
 func (c *Controller) Authorize() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, password := r.PathValue("id"), r.PathValue("password")

--- a/bean/internal/adapter/controller/auth/session.go
+++ b/bean/internal/adapter/controller/auth/session.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/whatis277/harvest/bean/internal/entity/model"
+)
+
+type authContextKey string
+
+const sessionContextKey = authContextKey("session")
+
+func NewContextWithSession(ctx context.Context, session *model.Session) context.Context {
+	return context.WithValue(ctx, sessionContextKey, session)
+}
+
+func SessionFromContext(ctx context.Context) *model.Session {
+	session, _ := ctx.Value(sessionContextKey).(*model.Session)
+	return session
+}


### PR DESCRIPTION
Authenticates the session token stored in the cookie

If the session is valid, it allows requests to continue
Otherwise, redirects back to `/get-started`

Passes the session in the request context for other methods to access
Then, uses the session's User ID in the app instead of hard-coded ID

Testing instructions:
1. `dc up --build bean`
2. Ensure there are no errors in the logs
3. Visit http://localhost:8080
4. Clear your cookies 
5. Visit http://localhost:8080/get-started
6. Enter `277@hey.com`
7. Visit http://localhost:8025 for the login URL
8. Once logged in, ensure the mocked data is shown
9. Now delete the cookie and refresh the page
10. You should get redirected back to `/get-started`
11. While there, login with a completely new email address
12. Visit http://localhost:8025 again for the login URL
13. Once logged in, ensure the new user has no data
14. Try adding new data for the user
15. Refresh the page ensure you're still logged in