### PR TITLE
bean: Add redirected authed users home

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -45,6 +45,12 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 
 func (c *Controller) Authorize() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		sessionToken, _ := getSessionToken(r)
+		if sessionToken != nil {
+			http.Redirect(w, r, "/home", http.StatusSeeOther)
+			return
+		}
+
 		id, password := r.PathValue("id"), r.PathValue("password")
 		if id == "" || password == "" {
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -9,6 +9,12 @@ import (
 
 func (c *Controller) LoginPage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		sessionToken, _ := getSessionToken(r)
+		if sessionToken != nil {
+			http.Redirect(w, r, "/home", http.StatusSeeOther)
+			return
+		}
+
 		c.renderLogin(w, &viewmodel.LoginViewData{})
 	}
 }


### PR DESCRIPTION
Doesn't allow authed users from accessing the Login and Authorize handlers

Testing instructions:
1. `dc up --build bean`
2. Ensure no errors in logs
3. Clear all cookies
4. Visit http://localhost:8080/get-started
5. Use a new email address 
6. Visit http://localhost:8025 for the login URL
7. Once you're logged in, ensure you are on `/home`
8. Manually try to go to http://localhost:8080/get-started
9. Manually try to go to http://localhost:8080/auth/test-id/test-password
10. Ensure in both situations you're redirected back to `/home`