### PR TITLE
bean: Add auth logout handler

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -199,6 +199,8 @@ func main() {
 
 	s.Use(authControler.Authenticate)
 
+	s.Route("GET /logout", authControler.Logout())
+
 	s.Route("GET /home", appController.HomePage())
 
 	s.Route("GET /cards/new", pmsController.CreatePage())

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -21,6 +21,12 @@ func (c *Controller) LoginPage() http.HandlerFunc {
 
 func (c *Controller) LoginForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		sessionToken, _ := getSessionToken(r)
+		if sessionToken != nil {
+			http.Redirect(w, r, "/home", http.StatusSeeOther)
+			return
+		}
+
 		email := r.FormValue("email")
 		if email == "" {
 			c.LoginView.Render(w, &viewmodel.LoginViewData{})

--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -1,0 +1,15 @@
+package auth
+
+import "net/http"
+
+func (c *Controller) Logout() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		session := SessionFromContext(r.Context())
+
+		c.Passwordless.Logout(session)
+
+		removeSessionTokenCookie(w)
+
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
+}

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -115,20 +115,7 @@ func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session
 	return session, nil
 }
 
-func (u *UseCase) Logout(sessionToken *model.SessionToken) error {
-	session, err := u.Sessions.FindByID(sessionToken.ID)
-	if err != nil {
-		return fmt.Errorf("failed to find session: %w", err)
-	}
-
-	if session == nil {
-		return fmt.Errorf("session not found")
-	}
-
-	if err := u.Hasher.Compare(sessionToken.Token, session.HashedToken); err != nil {
-		return fmt.Errorf("failed to compare session token: %w", err)
-	}
-
+func (u *UseCase) Logout(session *model.Session) error {
 	u.Sessions.Delete(session.ID)
 
 	return nil


### PR DESCRIPTION
Adds logout handler to auth controller

Also fixes forgotten redirect authed on login form from #135 

Testing instructions:
1. `dc up --build bean`
2. Ensure logs have no errors
3. Visit http://localhost:8080/get-started
4. Log with an email address
5. Don't close or refresh this tab, we'll need it 
6. Go to http://localhost:8025 for the login URL
7. Open the login URL in a separate tab
8. Now go back to the `/get-started` tab
9. Try to re-submit the form
10. You should be redirected to `/home`
11. While there, try to access `/get-started`
12. You should be redirected to `/home`
13. Now logout with http://localhost:8080/logout
14. Try to access `/get-started`
15. You should be redirected to `/get-started`
16. Now try to access http://localhost:8080/home
17. You should be redirected to `/get-started`
18. Try to access http://localhost:8080/logout again
19. You should be redirected to `/get-started`