### PR TITLE
bean: Add unique rand session tokens

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -57,7 +57,7 @@ func (c *Controller) Authorize() http.HandlerFunc {
 			return
 		}
 
-		sessionToken, err := c.Passwordless.Login(id, password)
+		sessionToken, err := c.Passwordless.Authorize(id, password)
 		if err != nil {
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -33,7 +33,7 @@ func (c *Controller) LoginForm() http.HandlerFunc {
 			return
 		}
 
-		err := c.Passwordless.SendEmail(email)
+		err := c.Passwordless.Login(email)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -76,12 +76,12 @@ func (u *UseCase) Authorize(id string, password string) (*model.SessionToken, er
 
 	csrfToken, err := generateRandomPassword()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate password: %w", err)
+		return nil, fmt.Errorf("failed to generate csrf token: %w", err)
 	}
 
 	csrfHash, err := u.Hasher.Hash(csrfToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to hash password: %w", err)
+		return nil, fmt.Errorf("failed to hash csrf token: %w", err)
 	}
 
 	session, err := u.Sessions.Create(user.ID, csrfHash, 14*24*time.Hour)

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -23,17 +23,16 @@ type UseCase struct {
 	Emailer interfaces.Emailer
 }
 
-func (u *UseCase) SendEmail(email string) error {
+func (u *UseCase) Login(email string) error {
 	if err := validateEmail(email); err != nil {
 		return fmt.Errorf("failed to validate email: %w", err)
 	}
 
-	rand, err := uuid.NewRandom()
+	password, err := generateRandomPassword()
 	if err != nil {
 		return fmt.Errorf("failed to generate password: %w", err)
 	}
 
-	password := rand.String()
 	hash, err := u.Hasher.Hash(password)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)
@@ -56,7 +55,7 @@ func (u *UseCase) SendEmail(email string) error {
 	return nil
 }
 
-func (u *UseCase) Login(id string, password string) (*model.SessionToken, error) {
+func (u *UseCase) Authorize(id string, password string) (*model.SessionToken, error) {
 	token, err := u.Tokens.FindUnexpired(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find token: %w", err)
@@ -75,14 +74,24 @@ func (u *UseCase) Login(id string, password string) (*model.SessionToken, error)
 		return nil, fmt.Errorf("failed to find or create user: %w", err)
 	}
 
-	session, err := u.Sessions.Create(user.ID, token.HashedToken, 14*24*time.Hour)
+	csrfToken, err := generateRandomPassword()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate password: %w", err)
+	}
+
+	csrfHash, err := u.Hasher.Hash(csrfToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	session, err := u.Sessions.Create(user.ID, csrfHash, 14*24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
 	sessionToken := &model.SessionToken{
 		ID:        session.ID,
-		Token:     password,
+		Token:     csrfToken,
 		ExpiresAt: session.ExpiresAt,
 	}
 
@@ -160,4 +169,13 @@ func (u *UseCase) buildEmailBody(tokenID, password string) string {
 			"Cheers."),
 		authUrl,
 	)
+}
+
+func generateRandomPassword() (string, error) {
+	rand, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return rand.String(), nil
 }


### PR DESCRIPTION
Instead of re-using the login token, generate and use a new random password.

It calls the token a CSRF token because it's kinda what it is.

Also renames the use case methods to match the controller

No testing needed