### PR TITLE
bean: Add memberships datasource

### DIFF
--- a/bean/internal/driver/datasource/membership/membership.go
+++ b/bean/internal/driver/datasource/membership/membership.go
@@ -1,0 +1,120 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/whatis277/harvest/bean/internal/entity/model"
+
+	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
+
+	"github.com/whatis277/harvest/bean/internal/driver/postgres"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type dataSource struct {
+	db *postgres.DB
+}
+
+func New(db *postgres.DB) interfaces.MembershipDataSource {
+	return &dataSource{db}
+}
+
+func (ds *dataSource) Create(userID string, createdAt time.Time) (*model.Membership, error) {
+	membership := &model.Membership{}
+
+	err := ds.db.Pool.
+		QueryRow(
+			context.Background(),
+			("INSERT INTO memberships"+
+				" (user_id, created_at)"+
+				" VALUES ($1, $2)"+
+				" ON CONFLICT (user_id) DO UPDATE"+
+				" SET"+
+				" created_at = $2,"+
+				" expires_at = NULL"+
+				" RETURNING *"),
+			userID, createdAt,
+		).
+		Scan(
+			&membership.UserID,
+			&membership.CreatedAt, &membership.ExpiresAt,
+		)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create membership: %w", err)
+	}
+
+	return membership, nil
+}
+
+func (ds *dataSource) Find(userID string) (*model.Membership, error) {
+	membership := &model.Membership{}
+
+	err := ds.db.Pool.
+		QueryRow(
+			context.Background(),
+			("SELECT * FROM memberships"+
+				" WHERE user_id = $1"),
+			userID,
+		).
+		Scan(
+			&membership.UserID,
+			&membership.CreatedAt, &membership.ExpiresAt,
+		)
+
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to find membership: %w", err)
+	}
+
+	return membership, nil
+}
+
+func (ds *dataSource) Update(userID string, expiresAt time.Time) (*model.Membership, error) {
+	membership := &model.Membership{}
+
+	err := ds.db.Pool.
+		QueryRow(
+			context.Background(),
+			("UPDATE memberships"+
+				" SET expires_at = $2"+
+				" WHERE user_id = $1"+
+				" RETURNING *"),
+			userID, expiresAt,
+		).
+		Scan(
+			&membership.UserID,
+			&membership.CreatedAt, &membership.ExpiresAt,
+		)
+
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to update membership: %w", err)
+	}
+
+	return membership, nil
+}
+
+func (ds *dataSource) Delete(userID string) error {
+	_, err := ds.db.Pool.
+		Exec(
+			context.Background(),
+			"DELETE FROM memberships WHERE user_id = $1",
+			userID,
+		)
+
+	if err != nil {
+		return fmt.Errorf("failed to delete membership: %w", err)
+	}
+
+	return nil
+}

--- a/bean/internal/driver/datasource/membership/membership_test.go
+++ b/bean/internal/driver/datasource/membership/membership_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/whatis277/harvest/bean/internal/driver/postgres/postgrestest"
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
+
+	"github.com/whatis277/harvest/bean/internal/driver/postgres/postgrestest"
 )
 
 var (
@@ -137,6 +138,10 @@ func find(t *testing.T, ds interfaces.MembershipDataSource) {
 
 		if membership.ExpiresAt == nil {
 			t.Errorf("expected non-nil expires at, got nil")
+		}
+
+		if membership.ExpiresAt.IsZero() {
+			t.Errorf("expected non-zero expires at, got: %s", membership.ExpiresAt)
 		}
 	})
 

--- a/bean/internal/driver/datasource/membership/membership_test.go
+++ b/bean/internal/driver/datasource/membership/membership_test.go
@@ -1,0 +1,228 @@
+package membership
+
+import (
+	"testing"
+	"time"
+
+	"github.com/whatis277/harvest/bean/internal/driver/postgres/postgrestest"
+	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
+)
+
+var (
+	newMember = "00000000-0000-0000-0000-000000000001"
+
+	activeMember  = "00000000-0000-0000-0003-000000000001"
+	expiredMember = "00000000-0000-0000-0003-000000000002"
+	nonMember     = "00000000-0000-0000-0003-000000000003"
+)
+
+func TestDataSource(t *testing.T) {
+	db := postgrestest.DBTest(t)
+	ds := New(db)
+
+	t.Run("create", func(t *testing.T) {
+		create(t, ds)
+	})
+
+	t.Run("find", func(t *testing.T) {
+		find(t, ds)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		update(t, ds)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		delete(t, ds)
+	})
+}
+
+func create(t *testing.T, ds interfaces.MembershipDataSource) {
+	t.Run("new_membership", func(t *testing.T) {
+		createdAt := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+
+		membership, err := ds.Create(newMember, createdAt)
+		if err != nil {
+			t.Fatalf("failed to create membership: %s", err)
+		}
+
+		if membership.UserID != newMember {
+			t.Errorf("expected user ID %s, got: %s", newMember, membership.UserID)
+		}
+
+		if !membership.CreatedAt.Equal(createdAt) {
+			t.Errorf("expected created at %s, got: %s", createdAt, membership.CreatedAt)
+		}
+
+		if membership.ExpiresAt != nil {
+			t.Errorf("expected nil expires at, got: %s", membership.ExpiresAt)
+		}
+
+		if err = ds.Delete(membership.UserID); err != nil {
+			t.Fatalf("failed to cleanup membership: %s", err)
+		}
+	})
+
+	t.Run("existing_membership", func(t *testing.T) {
+		createdAt := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+		expiresAt := createdAt.Add(time.Hour).Truncate(time.Millisecond)
+
+		membership, err := ds.Create(newMember, createdAt)
+		if err != nil {
+			t.Fatalf("failed to create membership: %s", err)
+		}
+
+		membership, err = ds.Update(membership.UserID, expiresAt)
+		if err != nil {
+			t.Fatalf("failed to update membership: %s", err)
+		}
+
+		newCreatedAt := createdAt.Add(time.Minute).Truncate(time.Millisecond)
+		membership, err = ds.Create(membership.UserID, newCreatedAt)
+		if err != nil {
+			t.Fatalf("failed to create membership: %s", err)
+		}
+
+		if membership.UserID != newMember {
+			t.Errorf("expected user ID %s, got: %s", newMember, membership.UserID)
+		}
+
+		if !membership.CreatedAt.Equal(newCreatedAt) {
+			t.Errorf("expected created at %s, got: %s", newCreatedAt, membership.CreatedAt)
+		}
+
+		if membership.ExpiresAt != nil {
+			t.Errorf("expected nil expires at, got: %s", membership.ExpiresAt)
+		}
+
+		if err = ds.Delete(membership.UserID); err != nil {
+			t.Fatalf("failed to cleanup membership: %s", err)
+		}
+	})
+}
+
+func find(t *testing.T, ds interfaces.MembershipDataSource) {
+	t.Run("existing_membership", func(t *testing.T) {
+		membership, err := ds.Find(activeMember)
+		if err != nil {
+			t.Fatalf("failed to find membership: %s", err)
+		}
+
+		if membership.UserID != activeMember {
+			t.Errorf("expected user ID %s, got: %s", activeMember, membership.UserID)
+		}
+
+		if membership.CreatedAt.IsZero() {
+			t.Errorf("expected non-zero created at, got: %s", membership.CreatedAt)
+		}
+
+		if membership.ExpiresAt != nil {
+			t.Errorf("expected nil expires at, got: %s", membership.ExpiresAt)
+		}
+	})
+
+	t.Run("expired_membership", func(t *testing.T) {
+		membership, err := ds.Find(expiredMember)
+		if err != nil {
+			t.Fatalf("failed to find membership: %s", err)
+		}
+
+		if membership.UserID != expiredMember {
+			t.Errorf("expected user ID %s, got: %s", expiredMember, membership.UserID)
+		}
+
+		if membership.CreatedAt.IsZero() {
+			t.Errorf("expected non-zero created at, got: %s", membership.CreatedAt)
+		}
+
+		if membership.ExpiresAt == nil {
+			t.Errorf("expected non-nil expires at, got nil")
+		}
+	})
+
+	t.Run("missing_membership", func(t *testing.T) {
+		membership, err := ds.Find(nonMember)
+		if err != nil {
+			t.Fatalf("failed to find membership: %s", err)
+		}
+
+		if membership != nil {
+			t.Errorf("expected nil membership, got: %v", membership)
+		}
+	})
+}
+
+func update(t *testing.T, ds interfaces.MembershipDataSource) {
+	t.Run("existing_membership", func(t *testing.T) {
+		createdAt := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+		expiresAt := createdAt.Add(time.Hour).Truncate(time.Millisecond)
+
+		membership, err := ds.Create(newMember, createdAt)
+		if err != nil {
+			t.Fatalf("failed to create membership: %s", err)
+		}
+
+		membership, err = ds.Update(membership.UserID, expiresAt)
+		if err != nil {
+			t.Fatalf("failed to update membership: %s", err)
+		}
+
+		if membership.UserID != newMember {
+			t.Errorf("expected user ID %s, got: %s", newMember, membership.UserID)
+		}
+
+		if !membership.CreatedAt.Equal(createdAt) {
+			t.Errorf("expected created at %s, got: %s", createdAt, membership.CreatedAt)
+		}
+
+		if !membership.ExpiresAt.Equal(expiresAt) {
+			t.Errorf("expected expires at %s, got: %s", expiresAt, membership.ExpiresAt)
+		}
+
+		if err = ds.Delete(membership.UserID); err != nil {
+			t.Fatalf("failed to cleanup membership: %s", err)
+		}
+	})
+
+	t.Run("missing_membership", func(t *testing.T) {
+		expiresAt := time.Now().Add(time.Hour)
+
+		membership, err := ds.Update(nonMember, expiresAt)
+		if err != nil {
+			t.Fatalf("failed to update membership: %s", err)
+		}
+
+		if membership != nil {
+			t.Errorf("expected nil membership, got: %v", membership)
+		}
+	})
+}
+
+func delete(t *testing.T, ds interfaces.MembershipDataSource) {
+	t.Run("existing_membership", func(t *testing.T) {
+		membership, err := ds.Create(newMember, time.Now())
+		if err != nil {
+			t.Fatalf("failed to create membership: %s", err)
+		}
+
+		if err = ds.Delete(membership.UserID); err != nil {
+			t.Fatalf("failed to delete membership: %s", err)
+		}
+
+		membership, err = ds.Find(membership.UserID)
+		if err != nil {
+			t.Fatalf("failed to find membership: %s", err)
+		}
+
+		if membership != nil {
+			t.Errorf("expected nil membership, got: %v", membership)
+		}
+	})
+
+	t.Run("missing_membership", func(t *testing.T) {
+		err := ds.Delete(nonMember)
+		if err != nil {
+			t.Fatalf("failed to delete membership: %s", err)
+		}
+	})
+}

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -38,6 +38,10 @@ func (u *UseCase) Cancel(userID string, expiresAt time.Time) (*model.Membership,
 		return nil, fmt.Errorf("failed to update membership: %v", err)
 	}
 
+	if membership == nil {
+		return nil, fmt.Errorf("membership not found")
+	}
+
 	return membership, nil
 }
 


### PR DESCRIPTION
Implements the membership datasource interface from #140 

Testing instructions:
1. `dc down --volumes`
2. `dc up bean`
3. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/datasource/membership -v`
4. Ensure there are no errors
5. `dc exec postgres psql -U postgres bean_test -c "select * from memberships;"`
6. Ensure there are only 3 rows