### PR TITLE
bean: Fix postgres err no rows import

### DIFF
--- a/bean/internal/driver/datasource/membership/membership.go
+++ b/bean/internal/driver/datasource/membership/membership.go
@@ -10,8 +10,6 @@ import (
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres"
-
-	"github.com/jackc/pgx/v5"
 )
 
 type dataSource struct {
@@ -65,7 +63,7 @@ func (ds *dataSource) Find(userID string) (*model.Membership, error) {
 			&membership.CreatedAt, &membership.ExpiresAt,
 		)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 
@@ -93,7 +91,7 @@ func (ds *dataSource) Update(userID string, expiresAt time.Time) (*model.Members
 			&membership.CreatedAt, &membership.ExpiresAt,
 		)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 

--- a/bean/internal/driver/datasource/subscription/subscription.go
+++ b/bean/internal/driver/datasource/subscription/subscription.go
@@ -9,8 +9,6 @@ import (
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres"
-
-	"github.com/jackc/pgx/v5"
 )
 
 type dataSource struct {
@@ -76,7 +74,7 @@ func (ds *dataSource) FindByID(userID string, id string) (*model.Subscription, e
 			&sub.CreatedAt, &sub.UpdatedAt,
 		)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 

--- a/bean/internal/driver/datasource/token/token.go
+++ b/bean/internal/driver/datasource/token/token.go
@@ -9,8 +9,6 @@ import (
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres"
-
-	"github.com/jackc/pgx/v5"
 )
 
 type dataSource struct {
@@ -57,7 +55,7 @@ func (ds *dataSource) FindUnexpired(id string) (*model.LoginToken, error) {
 		).
 		Scan(&token.ID, &token.Email, &token.HashedToken, &token.CreatedAt, &token.ExpiresAt)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 

--- a/bean/internal/driver/datasource/user/user.go
+++ b/bean/internal/driver/datasource/user/user.go
@@ -9,8 +9,6 @@ import (
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres"
-
-	"github.com/jackc/pgx/v5"
 )
 
 type dataSource struct {
@@ -54,7 +52,7 @@ func (ds *dataSource) FindById(id string) (*model.User, error) {
 		).
 		Scan(&user.ID, &user.Email, &user.CreatedAt, &user.UpdatedAt)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 
@@ -76,7 +74,7 @@ func (ds *dataSource) FindByEmail(email string) (*model.User, error) {
 		).
 		Scan(&user.ID, &user.Email, &user.CreatedAt, &user.UpdatedAt)
 
-	if err == pgx.ErrNoRows {
+	if err == postgres.ErrNowRows {
 		return nil, nil
 	}
 

--- a/bean/internal/driver/postgres/errors.go
+++ b/bean/internal/driver/postgres/errors.go
@@ -1,0 +1,9 @@
+package postgres
+
+import (
+	"github.com/jackc/pgx/v5"
+)
+
+var (
+	ErrNowRows = pgx.ErrNoRows
+)


### PR DESCRIPTION
Removes `pgx` usage in data sources

Exports `ErrNoRows` through the `postgres` driver

Testing instructions:
1. `dc up --build bean`
2. `dc exec -e INTEGRATION=1 bean go test ./... -v`
3. Ensure there are no errors