### PR TITLE
bean: Add membership check middleware

### DIFF
--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -53,3 +53,9 @@ func (c *Controller) HomePage() http.HandlerFunc {
 		}
 	}
 }
+
+func (c *Controller) OnboardingPage() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Onboarding page")
+	}
+}

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 
+	"github.com/whatis277/harvest/bean/internal/usecase/membership"
 	"github.com/whatis277/harvest/bean/internal/usecase/passwordless"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/interfaces"
@@ -10,6 +11,7 @@ import (
 
 type Controller struct {
 	Passwordless passwordless.UseCase
+	Memberships  membership.UseCase
 
 	LoginView interfaces.LoginView
 }

--- a/bean/internal/adapter/controller/auth/membership.go
+++ b/bean/internal/adapter/controller/auth/membership.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (c *Controller) CheckMembership(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		session := SessionFromContext(r.Context())
+
+		isMember, err := c.Memberships.Validate(session.UserID)
+		if err != nil {
+			fmt.Fprintf(w, "Error: %v", err)
+			return
+		}
+
+		if !isMember {
+			http.Redirect(w, r, "/onboarding", http.StatusSeeOther)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}

--- a/bean/internal/driver/server/helper.go
+++ b/bean/internal/driver/server/helper.go
@@ -8,8 +8,8 @@ func applyMiddleware(
 	handler http.Handler,
 	middlewares []func(http.Handler) http.HandlerFunc,
 ) http.Handler {
-	for _, middleware := range middlewares {
-		handler = middleware(handler)
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
 	}
 
 	return handler


### PR DESCRIPTION
Fixes the order in which middleware are applied

Adds a new middleware which checks for the membership

Adds basic onboarding page which will ask the user to become a member

Testing instructions:

**With member**:
1. `dc up --build bean`
2. Go to http://localhost:8080/get-started
3. Login with `277@hey.com`
4. Go to http://localhost:8025 for the auth URL
5. Ensure you're redirected to `/home`
6. Logout via http://localhost:8080/logout
7. Ensure you're redirected to `/`

**With non-member**:
1. `dc up --build bean`
2. Go to http://localhost:8080/get-started
3. Login with a new email
4. Go to http://localhost:8025 for the auth URL
5. Ensure you're redirected to `/onboarding`
6. Logout via http://localhost:8080/logout
7. Ensure you're redirected to `/` 