### PR TITLE
bean: Add memberships usecase find or create user

### DIFF
--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -17,9 +17,9 @@ type UseCase struct {
 }
 
 func (u *UseCase) Create(email string, createdAt time.Time) (*model.Membership, error) {
-	user, err := u.Users.FindByEmail(email)
+	user, err := u.findOrCreateUser(email)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find user by email: %v", err)
+		return nil, fmt.Errorf("failed to find or create user: %v", err)
 	}
 
 	if user == nil {
@@ -66,4 +66,22 @@ func (u *UseCase) Validate(userID string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
+	user, err := u.Users.FindByEmail(email)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	if user != nil {
+		return user, nil
+	}
+
+	user, err = u.Users.Create(email)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user: %w", err)
+	}
+
+	return user, nil
 }


### PR DESCRIPTION
Find or create the user when creating a membership

There's a small chance a user might subscribe before they have a user.
This ensures we don't miss that edge case.

No testing needed.