### PR TITLE
bean: Fix onboarding page wording

### DIFF
--- a/bean/internal/driver/template/onboarding.html
+++ b/bean/internal/driver/template/onboarding.html
@@ -5,7 +5,7 @@
 {{ define "content" }}
 <div class="section">
   <p>
-    Before you can use bean, <a target="_blank" href="https://youtu.be/QXDU-XN9Mxs">we want to charge you.</a>
+    Before you can use bean, <a target="_blank" href="https://youtu.be/QXDU-XN9Mxs">we want you to subscribe.</a>
     <br />
     We don't need the money. We just like the irony.
   </p>


### PR DESCRIPTION
Rewords "we want to charge you" -> "we want you to subscribe"

No testing needed