### PR TITLE
bean: Add buymeacoffee webhook events

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -206,6 +206,8 @@ func main() {
 
 	bmcController := buymeacoffee.Controller{
 		WebhookSecret: env.BuyMeACoffee.WebhookSecret,
+
+		Memberships: memberships,
 	}
 
 	s := server.New()

--- a/bean/internal/driver/buymeacoffee/types.go
+++ b/bean/internal/driver/buymeacoffee/types.go
@@ -1,0 +1,20 @@
+package buymeacoffee
+
+import (
+	"encoding/json"
+)
+
+type Event struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+type MembershipStartedData struct {
+	SupporterEmail     string `json:"supporter_email"`
+	CurrentPeriodStart int64  `json:"current_period_start"`
+}
+
+type MembershipCancelledData struct {
+	SupporterEmail   string `json:"supporter_email"`
+	CurrentPeriodEnd int64  `json:"current_period_end"`
+}

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -22,10 +22,6 @@ func (u *UseCase) Create(email string, createdAt time.Time) (*model.Membership, 
 		return nil, fmt.Errorf("failed to find or create user: %v", err)
 	}
 
-	if user == nil {
-		return nil, fmt.Errorf("user not found")
-	}
-
 	membership, err := u.Memberships.Create(user.ID, createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create membership: %v", err)
@@ -34,8 +30,17 @@ func (u *UseCase) Create(email string, createdAt time.Time) (*model.Membership, 
 	return membership, nil
 }
 
-func (u *UseCase) Cancel(userID string, expiresAt time.Time) (*model.Membership, error) {
-	membership, err := u.Memberships.Update(userID, expiresAt)
+func (u *UseCase) Cancel(email string, expiresAt time.Time) (*model.Membership, error) {
+	user, err := u.Users.FindByEmail(email)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user: %v", err)
+	}
+
+	if user == nil {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	membership, err := u.Memberships.Update(user.ID, expiresAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update membership: %v", err)
 	}


### PR DESCRIPTION
Handle `membership.started` and `membership.cancelled` buymeacoffee events

Testing setup: 

Creating the webhook:
1. `ngrok http 8080`
2. Go to https://www.buymeacoffee.com/webhooks
3. Add a new webhook `<ngrok-url>/webhooks/buymeacoffee`
4. Enable `membership.started` and `membership.cancelled` events
5. Copy the secret and add it under `BMC_WEBHOOK_SECRET=` to `harvest/bean/config/.env`
6. `dc up --build bean`

Testing instructions:
1. Send a test `membership.started` event
2. Go to http://localhost:8080/get-started
3. Login with `john@example.com`
4. Ensure you're sent to `/home` directly after login
5. Send a test `membership.cancelled` event 
6. Refresh the page on bean
7. Ensure you're sent to `/onboarding`
8. Send another test `membership.started` event
9. Refresh the page on bean
10. Ensure you're sent to `/home`
11. Send a test `membership.cancelled` event 
12. Refresh the page on bean
13. Ensure you're sent to `/onboarding`
14. Run `dc exec postgres psql -U postgres bean_test -c "update memberships set expires_at = '2024-03-16 12:56:41';"`
15. Refresh the page on bean
16. Ensure you're sent to `/home`