### PR TITLE
bean: Add env bypass membership flag

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	membershipRepo := membershipDS.New(db)
 	memberships := membershipUC.UseCase{
-		Bypass:      false,
+		Bypass:      env.FeatureFlags.BypassMembership,
 		Users:       userRepo,
 		Memberships: membershipRepo,
 	}

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -1,5 +1,7 @@
 # general
 BASE_URL=http://localhost:8080
+# feature flags
+BYPASS_MEMBERSHIP=true
 # database
 DB_NAME=bean_test
 DB_HOST=postgres

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -6,6 +6,11 @@ func New() (*Env, error) {
 		return nil, err
 	}
 
+	bypassMembership, err := lookupBool("BYPASS_MEMBERSHIP")
+	if err != nil {
+		return nil, err
+	}
+
 	dbName, err := lookup("DB_NAME")
 	if err != nil {
 		return nil, err
@@ -78,6 +83,9 @@ func New() (*Env, error) {
 
 	return &Env{
 		BaseURL: baseURL,
+		FeatureFlags: &FeatureFlags{
+			BypassMembership: bypassMembership,
+		},
 		DB: &DB{
 			Name:     dbName,
 			Host:     dbHost,

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -8,6 +8,8 @@ import (
 func TestEnv(t *testing.T) {
 	os.Setenv("BASE_URL", "base_url")
 
+	os.Setenv("BYPASS_MEMBERSHIP", "true")
+
 	os.Setenv("DB_NAME", "db_name")
 	os.Setenv("DB_HOST", "db_host")
 	os.Setenv("DB_PORT", "db_port")
@@ -34,6 +36,10 @@ func TestEnv(t *testing.T) {
 
 	if env.BaseURL != "base_url" {
 		t.Errorf("expected: %s, got: %s", "base_url", env.BaseURL)
+	}
+
+	if env.FeatureFlags.BypassMembership != true {
+		t.Errorf("bypass membership: expected: %t, got: %t", true, env.FeatureFlags.BypassMembership)
 	}
 
 	if env.DB.Name != "db_name" {

--- a/bean/internal/adapter/env/helpers.go
+++ b/bean/internal/adapter/env/helpers.go
@@ -13,3 +13,8 @@ func lookup(s string) (string, error) {
 
 	return v, nil
 }
+
+func lookupBool(s string) (bool, error) {
+	v, err := lookup(s)
+	return v == "true", err
+}

--- a/bean/internal/adapter/env/helpers_test.go
+++ b/bean/internal/adapter/env/helpers_test.go
@@ -22,3 +22,21 @@ func TestLookup(t *testing.T) {
 		}
 	})
 }
+
+func TestLookupBool(t *testing.T) {
+	t.Run("returns true", func(t *testing.T) {
+		os.Setenv("key", "true")
+
+		if v, _ := lookupBool("key"); v != true {
+			t.Errorf("expected: %t, got: %t", true, v)
+		}
+	})
+
+	t.Run("returns false", func(t *testing.T) {
+		os.Setenv("key", "false")
+
+		if v, _ := lookupBool("key"); v != false {
+			t.Errorf("expected: %t, got: %t", false, v)
+		}
+	})
+}

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -3,11 +3,17 @@ package env
 type Env struct {
 	BaseURL string
 
+	FeatureFlags *FeatureFlags
+
 	DB    *DB
 	Cache *Cache
 	SMTP  *SMTP
 
 	BuyMeACoffee *BuyMeACoffee
+}
+
+type FeatureFlags struct {
+	BypassMembership bool
 }
 
 type DB struct {


### PR DESCRIPTION
Feature flag to easily enable and disable membership

Testing instructions:
1. Set `BYPASS_MEMBERSHIP=true` in `harvest/bean/config/.env`
2. `dc down --volumes`
3. `dc up --build bean`
4. Go to http://localhost:8080/get-started
5. Login up with a new email `test@example.com`
6. Go to http://localhost:8025/ for the auth URL
7. Ensure you're taken directly to `/home` not to `/onboarding`