### PR TITLE
bean: Add improved documentation

### DIFF
--- a/bean/README.md
+++ b/bean/README.md
@@ -12,19 +12,32 @@ A subscription tracker for the rest of us.
 * Bean: http://localhost:8080
 * SMTP: http://localhost:8025
 
-## Dependencies
+### Production
+
+TODO
+
+### Documentation
+
+* [Migrations](./internal/driver/migration/README.md)
+* [Seeds](./internal/driver/seed/README.md)
+
+There are other documentations under `<dir>/README.md` where relevant.
+
+## Architecture
 
 ### Development
 
 * Postgres: Database
+* Redis: Cache
 * MailHog: SMTP server
 
 ### Production
 
 * Postgres: Database
+* Redis: Cache
 * Postmark: SMTP server
 
-## Guide
+## Guides
 
 ### Run
 
@@ -32,20 +45,35 @@ A subscription tracker for the rest of us.
 > docker compose up bean
 ```
 
-### Test
+### Tests
 
 ```bash
 > docker compose exec -e INTEGRATION=1 bean go test ./... -v
 ```
 
-### Migrate
+## Testing
 
-```bash
-> docker compose exec bean tern migrate --destination -+1
-```
+### General flow
 
-### Seed
+1. Visit the landing page at http://localhost:8080/
 
-```bash
-> docker compose exec bean tern migrate --config ./bean/config/.seed.tern.conf --migrations ./bean/internal/driver/seed --destination -+1
-```
+2. Click on "Get started" to sign up or login
+
+3. Enter your email address to sign up or login
+    * Use `277@hey.com` for existing data
+
+4. Visit mailhog at http://localhost:8025/
+
+5. Open the email sent and click on the auth URL
+
+6. Ensure you're redirected to http://localhost:8080/home
+
+7. Create a new card
+
+8. Add a new subscription to the card
+
+9. Delete the subscribe you just created
+
+10. Delete the card you just created
+
+11. Click on "Logout" to logout

--- a/bean/internal/driver/buymeacoffee/README.md
+++ b/bean/internal/driver/buymeacoffee/README.md
@@ -1,0 +1,33 @@
+# buymeacoffee
+BuyMeACoffee webhook event handlers.
+
+## Testing
+Instructions can help you test this.
+
+### Setup
+
+1. Expose the web app to the internet. We'll use `ngrok`.
+
+```bash
+ngrok http 8080
+```
+
+2. Create a new webhook at https://www.buymeacoffee.com/webhooks
+
+3. Set the URL to `<ngrok-url>/webhooks/buymeacoffee`
+
+4. Set the events to: `membership.started`, `membership.cancelled`
+
+5. Add the secret into `.env` under `BMC_WEBHOOK_SECRET=`
+
+6. Start bean
+
+### Test
+
+1. Select your webhook at https://www.buymeacoffee.com/webhooks
+
+2. Send a test event with the "Send test" button
+
+3. Ensure the request is logged in `ngrok`
+
+4. Ensure the response is displayed on BuyMeACoffee

--- a/bean/internal/driver/migration/README.md
+++ b/bean/internal/driver/migration/README.md
@@ -1,0 +1,32 @@
+# migration
+Migrations for bean.
+
+On production, they are run manually.
+
+On development, they are run on startup.
+
+## Dependencies
+
+### Config
+
+* [`.migration.tern.conf`](../../../config/.migration.tern.conf)
+
+### Third parties
+
+* [tern](https://pkg.go.dev/github.com/jackc/tern/v2)
+
+## Guide
+
+### New migration
+
+```bash
+docker compose exec bean tern new migration_name
+```
+
+### Run migration
+
+```bash
+docker compose exec bean tern migrate --destination +1
+```
+
+If you want to run a migration up and down, just use `--destination -+1`.

--- a/bean/internal/driver/seed/README.md
+++ b/bean/internal/driver/seed/README.md
@@ -1,0 +1,28 @@
+# seed
+Seeds for development and testing, not production.
+
+## Dependencies
+
+### Config
+
+* [`.seed.tern.conf`](../../../config/.seed.tern.conf)
+
+### Third parties
+
+* [tern](https://pkg.go.dev/github.com/jackc/tern/v2)
+
+## Guide
+
+### New migration
+
+```bash
+docker compose exec bean tern new seed_name --migrations ./bean/internal/driver/seed
+```
+
+### Run migration
+
+```bash
+docker compose exec bean tern migrate --config ./bean/config/.seed.tern.conf --migrations ./bean/internal/driver/seed --destination -+1
+```
+
+If you want to run a seed up and down, just use `--destination -+1`.

--- a/bean/internal/driver/smtp/README.md
+++ b/bean/internal/driver/smtp/README.md
@@ -1,0 +1,19 @@
+# smtp
+SMTP client for email sending.
+
+## Dependencies
+
+* Mailhog: http://localhost:8025/
+
+## Setup
+
+You need to setup these env variables
+
+```sh
+SMTP_HOST=smtp
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+```
+
+Make sure `SMTP_USERNAME` and `SMTP_PASSWORD` are empty for development to avoid TLS.


### PR DESCRIPTION
Distributes the documentation better.

Adds documentation for usage where needed. 

For example:
* migration, seed: how to create a new one and run it
* buymeacoffee: how to test webhooks locally
* smtp: a not-so-obvious note about value for env vars on development

No testing needed