### PR TITLE
bean: Fix subscription price placeholder

### DIFF
--- a/bean/internal/driver/template/subscription/create.html
+++ b/bean/internal/driver/template/subscription/create.html
@@ -56,7 +56,7 @@
         min="0.01"
         step="0.01"
         required
-        placeholder="1.99"
+        placeholder="2"
         {{ if .Form.Amount }}
         value="{{ .Form.Amount }}"
         {{ end }}


### PR DESCRIPTION
Small fix from `1.99` -> `2`

No testing needed