### PR TITLE
bean: Add caddy reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@
 
 # nginx config files
 !*/config/nginx.conf
+
+# caddy config files
+!*/config/caddy/Caddyfile

--- a/bean/README.md
+++ b/bean/README.md
@@ -39,12 +39,28 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 ## Guides
 
-### Run
+### Setup
+
+1. Create a `.env` file in `bean/config`
+
+The defaults from `.env.example` will be used.
+So, it can be empty for now.
 
 ```bash
 > touch bean/config/.env
+```
 
-> docker compose up bean
+2. Add `whatisbean.local` to `/etc/hosts`
+
+```bash
+# whatisbean.com local
+127.0.0.1 whatisbean.local
+```
+
+### Run
+
+```bash
+> docker compose up caddy bean
 ```
 
 ### Tests

--- a/bean/README.md
+++ b/bean/README.md
@@ -9,7 +9,7 @@ A subscription tracker for the rest of us.
 
 ### Development
 
-* Bean: http://localhost:8080
+* Bean: https://whatisbean.local
 * SMTP: http://localhost:8025
 
 ### Production
@@ -43,19 +43,19 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 1. Create a `.env` file in `bean/config`
 
-The defaults from `.env.example` will be used.
-So, it can be empty for now.
+    The defaults from `.env.example` will be used.
+    So, it can be empty for now.
 
-```bash
-> touch bean/config/.env
-```
+    ```bash
+    > touch bean/config/.env
+    ```
 
 2. Add `whatisbean.local` to `/etc/hosts`
 
-```bash
-# whatisbean.com local
-127.0.0.1 whatisbean.local
-```
+    ```bash
+    # whatisbean.com local
+    127.0.0.1 whatisbean.local
+    ```
 
 ### Run
 
@@ -73,7 +73,7 @@ So, it can be empty for now.
 
 ### General flow
 
-1. Visit the landing page at http://localhost:8080/
+1. Visit the landing page at https://whatisbean.local/
 
 2. Click on "Get started" to sign up or login
 
@@ -84,7 +84,7 @@ So, it can be empty for now.
 
 5. Open the email sent and click on the auth URL
 
-6. Ensure you're redirected to http://localhost:8080/home
+6. Ensure you're redirected to https://whatisbean.local/home
 
 7. Create a new card
 

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -1,5 +1,5 @@
 # general
-BASE_URL=http://localhost:8080
+BASE_URL=https://whatisbean.local
 # feature flags
 BYPASS_MEMBERSHIP=true
 # database

--- a/bean/internal/adapter/controller/auth/sessiontoken.go
+++ b/bean/internal/adapter/controller/auth/sessiontoken.go
@@ -8,7 +8,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
-const sessionCookieName = "session"
+const sessionCookieName = "__Host-session"
 
 func getSessionToken(r *http.Request) (*model.SessionToken, error) {
 	cookie, err := r.Cookie(sessionCookieName)
@@ -45,7 +45,7 @@ func addSessionTokenCookie(w http.ResponseWriter, token *model.SessionToken) err
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	return nil
@@ -59,6 +59,6 @@ func removeSessionTokenCookie(w http.ResponseWriter) {
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/bean/internal/driver/buymeacoffee/README.md
+++ b/bean/internal/driver/buymeacoffee/README.md
@@ -8,9 +8,9 @@ Instructions can help you test this.
 
 1. Expose the web app to the internet. We'll use `ngrok`.
 
-```bash
-ngrok http 8080
-```
+    ```bash
+    ngrok http whatisbean.local:443 --host-header=rewrite
+    ```
 
 2. Create a new webhook at https://www.buymeacoffee.com/webhooks
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     env_file:
       - ./bean/config/.env.example
       - ./bean/config/.env
-    ports:
-      - "8080:8080"
+    networks:
+      - harvest
     volumes:
       - ./bean:/go/src/bean
     depends_on:
@@ -28,6 +28,8 @@ services:
     image: nginx:alpine
     ports:
       - "8081:80"
+    networks:
+      - harvest
     volumes:
       - ./pear/html:/usr/share/nginx/html
       - ./pear/config/nginx.conf:/etc/nginx/conf.d/default.conf
@@ -37,8 +39,9 @@ services:
     image: mailhog/mailhog:latest
     restart: always
     ports:
-      - "1025:1025"
       - "8025:8025"
+    networks:
+      - harvest
     volumes:
       - mailhog-data:/var/lib/mailhog
 
@@ -46,8 +49,8 @@ services:
     <<: *common
     image: redis:latest
     restart: always
-    ports:
-      - "6379:6379"
+    networks:
+      - harvest
     volumes:
       - redis-data:/data
     healthcheck:
@@ -64,8 +67,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: bean_test
-    ports:
-      - "5432:5432"
+    networks:
+      - harvest
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -74,7 +77,27 @@ services:
       timeout: 1s
       retries: 5
 
+  caddy:
+    <<: *common
+    image: caddy:latest
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - harvest
+    volumes:
+      - ./shared/config/caddy:/etc/caddy
+      - caddy_data:/data
+      - caddy_config:/config
+
+networks:
+  harvest:
+    driver: bridge
+
 volumes:
-  postgres-data:
-  redis-data:
   mailhog-data:
+  redis-data:
+  postgres-data:
+  caddy_data:
+  caddy_config:

--- a/shared/config/caddy/Caddyfile
+++ b/shared/config/caddy/Caddyfile
@@ -1,0 +1,3 @@
+whatisbean.local {
+	reverse_proxy bean:8080
+}


### PR DESCRIPTION
Basic reverse proxy using caddy

I chose caddy for simplicity over nginx - less code to maintain

Ironic, after writing `bean` from scratch with golang. But I like irony

Testing instructions:

1. Follow the [general flow testing](../tree/bean-reverse-proxy/bean#general-flow)

2. Ensure everything is working correctly

3. Follow the [buymeacoffee webhook testing](../tree/bean-reverse-proxy/bean/internal/driver/buymeacoffee/README.md#testing)

4. Ensure everything is working correctly