### PR TITLE
bean: Add http session support

### DIFF
--- a/bean/README.md
+++ b/bean/README.md
@@ -9,7 +9,7 @@ A subscription tracker for the rest of us.
 
 ### Development
 
-* Bean: https://whatisbean.local
+* Bean: http://whatisbean.local
 * SMTP: http://localhost:8025
 
 ### Production
@@ -73,7 +73,7 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 ### General flow
 
-1. Visit the landing page at https://whatisbean.local/
+1. Visit the landing page at http://whatisbean.local/
 
 2. Click on "Get started" to sign up or login
 
@@ -84,7 +84,7 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 5. Open the email sent and click on the auth URL
 
-6. Ensure you're redirected to https://whatisbean.local/home
+6. Ensure you're redirected to http://whatisbean.local/home
 
 7. Create a new card
 

--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -174,6 +174,8 @@ func main() {
 	}
 
 	authController := auth.Controller{
+		BypassHTTPS: env.FeatureFlags.BypassHTTPS,
+
 		Passwordless: passwordlessAuth,
 		Memberships:  memberships,
 

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -1,6 +1,7 @@
 # general
-BASE_URL=https://whatisbean.local
+BASE_URL=http://whatisbean.local
 # feature flags
+BYPASS_HTTPS=true
 BYPASS_MEMBERSHIP=true
 # database
 DB_NAME=bean_test

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -22,21 +22,21 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sessionToken, err := c.getSessionToken(r)
 		if err != nil || sessionToken == nil {
-			c.cleanSessionToken(w)
+			c.cleanupSessionToken(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}
 
 		session, err := c.Passwordless.Authenticate(sessionToken)
 		if err != nil || session == nil {
-			c.cleanSessionToken(w)
+			c.cleanupSessionToken(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}
 
 		err = c.createSessionToken(w, sessionToken)
 		if err != nil {
-			c.cleanSessionToken(w)
+			c.cleanupSessionToken(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}
@@ -69,7 +69,7 @@ func (c *Controller) Authorize() http.HandlerFunc {
 
 		err = c.createSessionToken(w, sessionToken)
 		if err != nil {
-			c.cleanSessionToken(w)
+			c.cleanupSessionToken(w)
 			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
 			return
 		}

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -9,7 +9,7 @@ import (
 
 func (c *Controller) LoginPage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		sessionToken, _ := getSessionToken(r)
+		sessionToken, _ := c.getSessionToken(r)
 		if sessionToken != nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return
@@ -21,7 +21,7 @@ func (c *Controller) LoginPage() http.HandlerFunc {
 
 func (c *Controller) LoginForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		sessionToken, _ := getSessionToken(r)
+		sessionToken, _ := c.getSessionToken(r)
 		if sessionToken != nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return

--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -8,7 +8,7 @@ func (c *Controller) Logout() http.HandlerFunc {
 
 		c.Passwordless.Logout(session)
 
-		c.cleanSessionToken(w)
+		c.cleanupSessionToken(w)
 
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -8,7 +8,7 @@ func (c *Controller) Logout() http.HandlerFunc {
 
 		c.Passwordless.Logout(session)
 
-		removeSessionTokenCookie(w)
+		c.cleanSessionToken(w)
 
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/auth/sessiontoken.go
+++ b/bean/internal/adapter/controller/auth/sessiontoken.go
@@ -8,10 +8,9 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
-const sessionCookieName = "__Host-session"
-
-func getSessionToken(r *http.Request) (*model.SessionToken, error) {
-	cookie, err := r.Cookie(sessionCookieName)
+func (c *Controller) getSessionToken(r *http.Request) (*model.SessionToken, error) {
+	cookie := c.sessionTokenCookie()
+	cookie, err := r.Cookie(cookie.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session token: %w", err)
 	}
@@ -30,7 +29,7 @@ func getSessionToken(r *http.Request) (*model.SessionToken, error) {
 	return &token, nil
 }
 
-func addSessionTokenCookie(w http.ResponseWriter, token *model.SessionToken) error {
+func (c *Controller) createSessionToken(w http.ResponseWriter, token *model.SessionToken) error {
 	json, err := token.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("failed to marshal session token: %w", err)
@@ -38,27 +37,39 @@ func addSessionTokenCookie(w http.ResponseWriter, token *model.SessionToken) err
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(json))
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    encoded,
-		Expires:  token.ExpiresAt,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	cookie := c.sessionTokenCookie()
+
+	cookie.Value = encoded
+	cookie.Expires = token.ExpiresAt
+
+	http.SetCookie(w, cookie)
 
 	return nil
 }
 
-func removeSessionTokenCookie(w http.ResponseWriter) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    "",
-		MaxAge:   -1,
+func (c *Controller) cleanSessionToken(w http.ResponseWriter) {
+	cookie := c.sessionTokenCookie()
+	cookie.MaxAge = -1
+
+	http.SetCookie(w, cookie)
+}
+
+func (c *Controller) sessionTokenCookie() *http.Cookie {
+	if c.BypassHTTPS {
+		return &http.Cookie{
+			Name:     "session",
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   false,
+			SameSite: http.SameSiteLaxMode,
+		}
+	}
+
+	return &http.Cookie{
+		Name:     "__Host-session",
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
-	})
+	}
 }

--- a/bean/internal/adapter/controller/auth/sessiontoken.go
+++ b/bean/internal/adapter/controller/auth/sessiontoken.go
@@ -47,7 +47,7 @@ func (c *Controller) createSessionToken(w http.ResponseWriter, token *model.Sess
 	return nil
 }
 
-func (c *Controller) cleanSessionToken(w http.ResponseWriter) {
+func (c *Controller) cleanupSessionToken(w http.ResponseWriter) {
 	cookie := c.sessionTokenCookie()
 	cookie.MaxAge = -1
 

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -6,6 +6,11 @@ func New() (*Env, error) {
 		return nil, err
 	}
 
+	bypassHTTPS, err := lookupBool("BYPASS_HTTPS")
+	if err != nil {
+		return nil, err
+	}
+
 	bypassMembership, err := lookupBool("BYPASS_MEMBERSHIP")
 	if err != nil {
 		return nil, err
@@ -84,6 +89,7 @@ func New() (*Env, error) {
 	return &Env{
 		BaseURL: baseURL,
 		FeatureFlags: &FeatureFlags{
+			BypassHTTPS:      bypassHTTPS,
 			BypassMembership: bypassMembership,
 		},
 		DB: &DB{

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -8,6 +8,7 @@ import (
 func TestEnv(t *testing.T) {
 	os.Setenv("BASE_URL", "base_url")
 
+	os.Setenv("BYPASS_HTTPS", "true")
 	os.Setenv("BYPASS_MEMBERSHIP", "true")
 
 	os.Setenv("DB_NAME", "db_name")
@@ -36,6 +37,10 @@ func TestEnv(t *testing.T) {
 
 	if env.BaseURL != "base_url" {
 		t.Errorf("expected: %s, got: %s", "base_url", env.BaseURL)
+	}
+
+	if env.FeatureFlags.BypassHTTPS != true {
+		t.Errorf("bypass https: expected: %t, got: %t", true, env.FeatureFlags.BypassHTTPS)
 	}
 
 	if env.FeatureFlags.BypassMembership != true {

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -13,6 +13,7 @@ type Env struct {
 }
 
 type FeatureFlags struct {
+	BypassHTTPS      bool
 	BypassMembership bool
 }
 

--- a/bean/internal/driver/buymeacoffee/README.md
+++ b/bean/internal/driver/buymeacoffee/README.md
@@ -9,7 +9,7 @@ Instructions can help you test this.
 1. Expose the web app to the internet. We'll use `ngrok`.
 
     ```bash
-    ngrok http whatisbean.local:443 --host-header=rewrite
+    ngrok http whatisbean.local:80 --host-header=rewrite
     ```
 
 2. Create a new webhook at https://www.buymeacoffee.com/webhooks


### PR DESCRIPTION
Support session on non-HTTPS

This will be needed for when we drop Caddy and use NGINX
It will save us the hassle of supporting HTTPS locally 

Testing instructions:
1. Follow the [Testing > General Flow](../blob/bean-httpless-session/bean/README.md#general-flow)

2. Ensure it works fine

3. Inspect the page -> Applications -> Cookies and ensure the cookie has no "Secure"