### PR TITLE
bean: Add buymeacoffee event livemode filter

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -207,7 +207,8 @@ func main() {
 	}
 
 	bmcController := buymeacoffee.Controller{
-		WebhookSecret: env.BuyMeACoffee.WebhookSecret,
+		AcceptTestEvents: env.BuyMeACoffee.AcceptTestEvents,
+		WebhookSecret:    env.BuyMeACoffee.WebhookSecret,
 
 		Memberships: memberships,
 	}

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -21,6 +21,7 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 # buymeacoffee webhook
 BMC_WEBHOOK_SECRET=
+BMC_ACCEPT_TEST_EVENTS=true
 # tern for migration
 TERN_CONFIG=./bean/config/.migration.tern.conf
 TERN_MIGRATIONS=./bean/internal/driver/migration

--- a/bean/internal/adapter/env/env.go
+++ b/bean/internal/adapter/env/env.go
@@ -81,6 +81,11 @@ func New() (*Env, error) {
 		return nil, err
 	}
 
+	bmcAcceptTestEvents, err := lookupBool("BMC_ACCEPT_TEST_EVENTS")
+	if err != nil {
+		return nil, err
+	}
+
 	bmcWebhookSecret, err := lookup("BMC_WEBHOOK_SECRET")
 	if err != nil {
 		return nil, err
@@ -112,7 +117,8 @@ func New() (*Env, error) {
 			Password: smtpPassword,
 		},
 		BuyMeACoffee: &BuyMeACoffee{
-			WebhookSecret: bmcWebhookSecret,
+			AcceptTestEvents: bmcAcceptTestEvents,
+			WebhookSecret:    bmcWebhookSecret,
 		},
 	}, nil
 }

--- a/bean/internal/adapter/env/env_test.go
+++ b/bean/internal/adapter/env/env_test.go
@@ -27,6 +27,7 @@ func TestEnv(t *testing.T) {
 	os.Setenv("SMTP_USERNAME", "smtp_username")
 	os.Setenv("SMTP_PASSWORD", "smtp_password")
 
+	os.Setenv("BMC_ACCEPT_TEST_EVENTS", "true")
 	os.Setenv("BMC_WEBHOOK_SECRET", "bmc_webhook_secret")
 
 	env, err := New()
@@ -97,6 +98,10 @@ func TestEnv(t *testing.T) {
 
 	if env.SMTP.Password != "smtp_password" {
 		t.Errorf("expected: %s, got: %s", "smtp_password", env.SMTP.Password)
+	}
+
+	if env.BuyMeACoffee.AcceptTestEvents != true {
+		t.Errorf("expected: %t, got: %t", true, env.BuyMeACoffee.AcceptTestEvents)
 	}
 
 	if env.BuyMeACoffee.WebhookSecret != "bmc_webhook_secret" {

--- a/bean/internal/adapter/env/types.go
+++ b/bean/internal/adapter/env/types.go
@@ -40,5 +40,6 @@ type SMTP struct {
 }
 
 type BuyMeACoffee struct {
-	WebhookSecret string
+	AcceptTestEvents bool
+	WebhookSecret    string
 }

--- a/bean/internal/driver/buymeacoffee/buymeacoffee.go
+++ b/bean/internal/driver/buymeacoffee/buymeacoffee.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Controller struct {
-	WebhookSecret string
+	AcceptTestEvents bool
+	WebhookSecret    string
 
 	Memberships membership.UseCase
 }
@@ -48,6 +49,11 @@ func (c *Controller) Webhook() http.HandlerFunc {
 		err = json.Unmarshal(body, &event)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if !event.LiveMode && !c.AcceptTestEvents {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 

--- a/bean/internal/driver/buymeacoffee/types.go
+++ b/bean/internal/driver/buymeacoffee/types.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Event struct {
-	Type string          `json:"type"`
-	Data json.RawMessage `json:"data"`
+	Type     string          `json:"type"`
+	LiveMode bool            `json:"live_mode"`
+	Data     json.RawMessage `json:"data"`
 }
 
 type MembershipStartedData struct {


### PR DESCRIPTION
Only handles the webhooks if we are in live mode or we want to accept test events

Testing instructions:
1. `ngrok http 80` 
2. Create a webhook at https://www.buymeacoffee.com/webhooks
3. Copy the webhook secret and add it to `.env` under `BMC_WEBHOOK_SECRET`
4. Set `BMC_ACCEPT_TEST_EVENTS=false`
5. `dc up nginx bean`
6. Send a test event for `membership.started`
7. Run `dc exec postgres psql -U postgres bean_test -c "select * from memberships;"`
8. Ensure there are only 3 rows starting with a lot of 0s 
9. `dc down`
10. Set `BMC_ACCEPT_TEST_EVENTS=true`
11. `dc up nginx bean`
12. Send a test event from `membership.started`
13. Run `dc exec postgres psql -U postgres bean_test -c "select * from memberships;"`
14. Ensure there's a new row with a random UUID