### PR TITLE
bean: Add request rate limits

### DIFF
--- a/bean/config/nginx.conf
+++ b/bean/config/nginx.conf
@@ -1,8 +1,14 @@
+limit_req_zone $binary_remote_addr zone=bean_limit:10m rate=5r/s;
+
 server {
   listen 80;
   server_name whatisbean.local;
 
+  set $bean http://bean:8080;
+
   location / {
-    proxy_pass http://bean:8080;
+    limit_req zone=bean_limit burst=10 nodelay;
+
+    proxy_pass $bean;
   }
 }

--- a/bean/config/nginx.conf
+++ b/bean/config/nginx.conf
@@ -4,11 +4,9 @@ server {
   listen 80;
   server_name whatisbean.local;
 
-  set $bean http://bean:8080;
-
   location / {
     limit_req zone=bean_limit burst=10 nodelay;
 
-    proxy_pass $bean;
+    proxy_pass http://bean:8080;
   }
 }

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -52,7 +52,8 @@ type UserDataSource interface {
 type LoginTokenDataSource interface {
 	Create(email string, hashedToken string) (*model.LoginToken, error)
 
-	FindUnexpired(id string) (*model.LoginToken, error)
+	FindUnexpiredByEmail(email string) (*model.LoginToken, error)
+	FindUnexpiredByID(id string) (*model.LoginToken, error)
 
 	Delete(id string) error
 }

--- a/shared/config/nginx/nginx.conf
+++ b/shared/config/nginx/nginx.conf
@@ -27,5 +27,8 @@ http {
 
   server_tokens off;
 
+  limit_req_status 429;
+  limit_conn_status 429;
+
   include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Rate limits on NGINX to 5 requests per second.

Also, it only sends a new login email every 10 minutes.
This helps prevent abuse on the same email.

The form can still be abused by sending login attempts to different emails.
That will be addressed in a future PR.

Testing instructions:
1. Visit http://whatisbean.local/get-started
2. Refresh the page continuously until you feel like giving up
3. Pray and hope that you hit the rate limit
4. Enter an email and try to login
5. Refresh the page with form re-submission multiple times
6. Check http://localhost:8025/ and ensure there's only 1 email