### PR TITLE
bean: Restrict login form to members

### DIFF
--- a/bean/README.md
+++ b/bean/README.md
@@ -75,9 +75,9 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 1. Visit the landing page at http://whatisbean.local/
 
-2. Click on "Get started" to sign up or login
+2. Click on "Login" to login
 
-3. Enter your email address to sign up or login
+3. Enter your email address to login
     * Use `277@hey.com` for existing data
 
 4. Visit mailhog at http://localhost:8025/

--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -221,8 +221,8 @@ func main() {
 
 	s.Route("GET /auth/{id}/{password}", authController.Authorize())
 
-	s.Route("GET /get-started", authController.LoginPage())
-	s.Route("POST /get-started", authController.LoginForm())
+	s.Route("GET /login", authController.LoginPage())
+	s.Route("POST /login", authController.LoginForm())
 
 	s.Route("POST /webhooks/buymeacoffee", bmcController.Webhook())
 

--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -61,7 +61,7 @@ func (c *Controller) OnboardingPage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		session := auth.SessionFromContext(r.Context())
 
-		isMember, _ := c.Memberships.Validate(session.UserID)
+		isMember, _ := c.Memberships.CheckByID(session.UserID)
 		if isMember {
 			http.Redirect(w, r, "/home", http.StatusFound)
 			return

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -33,7 +33,26 @@ func (c *Controller) LoginForm() http.HandlerFunc {
 			return
 		}
 
-		err := c.Passwordless.Login(email)
+		password := r.FormValue("password")
+		if password != "" {
+			c.LoginView.Render(w, &viewmodel.LoginViewData{})
+			return
+		}
+
+		isMember, err := c.Memberships.CheckByEmail(email)
+		if err != nil {
+			fmt.Fprintf(w, "Error: %v", err)
+			return
+		}
+
+		if !isMember {
+			c.renderLogin(w, &viewmodel.LoginViewData{
+				Email: email,
+			})
+			return
+		}
+
+		err = c.Passwordless.Login(email)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/adapter/controller/auth/membership.go
+++ b/bean/internal/adapter/controller/auth/membership.go
@@ -9,7 +9,7 @@ func (c *Controller) CheckMembership(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		session := SessionFromContext(r.Context())
 
-		isMember, err := c.Memberships.Validate(session.UserID)
+		isMember, err := c.Memberships.CheckByID(session.UserID)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/driver/template/landing.html
+++ b/bean/internal/driver/template/landing.html
@@ -1,7 +1,9 @@
 {{ define "navbar" }}
 <a>About</a>
 &nbsp;·&nbsp;
-<a href="/get-started">Get started</a>
+<a href="/signup">Sign up</a>
+&nbsp;·&nbsp;
+<a href="/login">Login</a>
 {{ end }}
 
 {{ define "content" }}

--- a/bean/internal/driver/template/login.html
+++ b/bean/internal/driver/template/login.html
@@ -1,7 +1,9 @@
 {{ define "navbar" }}
 <a href="/">About</a>
 &nbsp;·&nbsp;
-<a>Get started</a>
+<a href="/signup">Sign up</a>
+&nbsp;·&nbsp;
+<a>Login</a>
 {{ end }}
 
 {{ define "content" }}
@@ -9,10 +11,12 @@
   <div class="subsection">
   {{ if .Email }}
     <p>We sent a login link to <strong>{{ .Email }}</strong>.</p>
-    <p>Use it to login soon. It expires in 10 minutes.</p>
+    <br />
+    <p>Use it soon. It expires in 10 minutes.</p>
+    <p>We won't send new one until it expires.</p>
   {{ else }}
     <p>Enter your email and we'll send you a link to log in.</p>
-    <p>If you don't have an account, we'll create one for you.</p>
+    <p>We won't email a random person so <a href="/signup">sign up first</a>.</p>
   {{ end }}
   </div>
 
@@ -20,6 +24,7 @@
     <form name="login" method="post">
       <label for="email">Email</label>
       <input id="email" type="email" name="email" />
+      <input id="password" type="hidden" name="password" />
       <br />
       <input type="submit" value="Login" />
     </form>

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -52,7 +52,7 @@ func (u *UseCase) Cancel(email string, expiresAt time.Time) (*model.Membership, 
 	return membership, nil
 }
 
-func (u *UseCase) Validate(userID string) (bool, error) {
+func (u *UseCase) CheckByID(userID string) (bool, error) {
 	if u.Bypass {
 		return true, nil
 	}
@@ -71,6 +71,23 @@ func (u *UseCase) Validate(userID string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (u *UseCase) CheckByEmail(email string) (bool, error) {
+	if u.Bypass {
+		return true, nil
+	}
+
+	user, err := u.Users.FindByEmail(email)
+	if err != nil {
+		return false, fmt.Errorf("failed to find user: %v", err)
+	}
+
+	if user == nil {
+		return false, nil
+	}
+
+	return u.CheckByID(user.ID)
 }
 
 func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {


### PR DESCRIPTION
Only members will receive a login URL.

This helps us prevent abusing the form.

Also adds a hidden "password" field. 
If filled, doesn't process the login request.

Testing instructions:
1. Run `echo "BYPASS_MEMBERSHIP=false" >> bean/config/.env`
1. `dc up nginx bean`
1. Visit http://whatisbean.local/
1. Try to login with `john@example.com`
1. Check [mailhog](http://localhost:8025)
2. Ensure there's no email
3. Try to login with `277@hey.com`
4. Check [mailhog](http://localhost:8025)
5. Ensure there's an email