### PR TITLE
bean: Fix passwordless login bugs

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -24,21 +24,21 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 		sessionToken, err := c.getSessionToken(r)
 		if err != nil || sessionToken == nil {
 			c.cleanupSessionToken(w)
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 
 		session, err := c.Passwordless.Authenticate(sessionToken)
 		if err != nil || session == nil {
 			c.cleanupSessionToken(w)
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 
 		err = c.createSessionToken(w, sessionToken)
 		if err != nil {
 			c.cleanupSessionToken(w)
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 
@@ -58,20 +58,20 @@ func (c *Controller) Authorize() http.HandlerFunc {
 
 		id, password := r.PathValue("id"), r.PathValue("password")
 		if id == "" || password == "" {
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 
 		sessionToken, err := c.Passwordless.Authorize(id, password)
 		if err != nil {
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 
 		err = c.createSessionToken(w, sessionToken)
 		if err != nil {
 			c.cleanupSessionToken(w)
-			http.Redirect(w, r, "/get-started", http.StatusSeeOther)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -39,20 +39,7 @@ func (c *Controller) LoginForm() http.HandlerFunc {
 			return
 		}
 
-		isMember, err := c.Memberships.CheckByEmail(email)
-		if err != nil {
-			fmt.Fprintf(w, "Error: %v", err)
-			return
-		}
-
-		if !isMember {
-			c.renderLogin(w, &viewmodel.LoginViewData{
-				Email: email,
-			})
-			return
-		}
-
-		err = c.Passwordless.Login(email)
+		err := c.Passwordless.Login(email)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -28,6 +28,15 @@ func (u *UseCase) Login(email string) error {
 		return fmt.Errorf("failed to validate email: %w", err)
 	}
 
+	user, err := u.Users.FindByEmail(email)
+	if err != nil {
+		return fmt.Errorf("failed to find user: %w", err)
+	}
+
+	if user == nil {
+		return nil
+	}
+
 	token, err := u.Tokens.FindUnexpiredByEmail(email)
 	if err != nil {
 		return fmt.Errorf("failed to find existing token: %w", err)


### PR DESCRIPTION
Two bugs are fixed

First is forgotten `/get-started` redirection URLs

Second is changing membership check to a user check
Even if a user isn't a member anymore, let them login

The changes are logical so no testing needed
The second bug was a result of lack of thinking

No testing needed