### PR TITLE
bean: Send membership started login email

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -218,7 +218,8 @@ func main() {
 		AcceptTestEvents: env.BuyMeACoffee.AcceptTestEvents,
 		WebhookSecret:    env.BuyMeACoffee.WebhookSecret,
 
-		Memberships: memberships,
+		Passwordless: passwordlessAuth,
+		Memberships:  memberships,
 	}
 
 	s := server.New()


### PR DESCRIPTION
Sends a passwordless login email on `membership.started` event

Testing instructions:
1. Setup the webhook using [the docs](https://github.com/whatis277/harvest/blob/main/bean/internal/driver/buymeacoffee/README.md#setup)
2. Send a test event for `membership.started`
3. Check [mailhog](http://localhost:8025)
4. Ensure there's an email for `john@example.com`
