### PR TITLE
bean: Pass down context to db and cache

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	estimatorUC "github.com/whatis277/harvest/bean/internal/usecase/estimator"
 	membershipUC "github.com/whatis277/harvest/bean/internal/usecase/membership"
@@ -45,7 +47,10 @@ func main() {
 		)
 	}
 
-	db, err := postgres.New(&postgres.DSNBuilder{
+	dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dbCancel()
+
+	db, err := postgres.New(dbCtx, &postgres.DSNBuilder{
 		Host:     env.DB.Host,
 		Port:     env.DB.Port,
 		Name:     env.DB.Name,
@@ -60,7 +65,10 @@ func main() {
 	}
 	defer db.Close()
 
-	cache, err := redis.New(&redis.Config{
+	cacheCtx, cacheCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cacheCancel()
+
+	cache, err := redis.New(cacheCtx, &redis.Config{
 		Host:     env.Cache.Host,
 		Port:     env.Cache.Port,
 		Username: env.Cache.Username,

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -33,6 +33,9 @@ func TestDataSource(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
 	t.Run("new_session", func(t *testing.T) {
 		session, err := ds.Create("action-create", "hashed-token", 10*time.Second)
 		if err != nil {
@@ -68,7 +71,7 @@ func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
 			t.Errorf("expected expires at to be 10 seconds after created at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(context.Background(), session.ID).Val()
+		ttl := cache.Client.TTL(ctx, session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -125,6 +128,9 @@ func findById(t *testing.T, ds interfaces.SessionDataSource) {
 }
 
 func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
 	t.Run("existing_session", func(t *testing.T) {
 		session, err := ds.Create("action-refresh", "hashed-token", 10*time.Second)
 		if err != nil {
@@ -136,7 +142,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 10 seconds after updated at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(context.Background(), session.ID).Val()
+		ttl := cache.Client.TTL(ctx, session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -151,7 +157,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 20 seconds after updated at, got: %s", duration)
 		}
 
-		ttl = cache.Client.TTL(context.Background(), session.ID).Val()
+		ttl = cache.Client.TTL(ctx, session.ID).Val()
 		if ttl != 20*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 20*time.Second, ttl)
 		}

--- a/bean/internal/driver/postgres/postgres.go
+++ b/bean/internal/driver/postgres/postgres.go
@@ -11,13 +11,13 @@ type DB struct {
 	Pool *pgxpool.Pool
 }
 
-func New(builder *DSNBuilder) (*DB, error) {
-	pool, err := pgxpool.New(context.Background(), dsn(builder))
+func New(ctx context.Context, builder *DSNBuilder) (*DB, error) {
+	pool, err := pgxpool.New(ctx, dsn(builder))
 	if err != nil {
 		return nil, errors.New("error creating pool")
 	}
 
-	err = pool.Ping(context.Background())
+	err = pool.Ping(ctx)
 	if err != nil {
 		return nil, errors.New("error pinging pool")
 	}

--- a/bean/internal/driver/postgres/postgres_test.go
+++ b/bean/internal/driver/postgres/postgres_test.go
@@ -3,6 +3,7 @@ package postgres_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres/postgrestest"
 )
@@ -10,7 +11,10 @@ import (
 func TestDB(t *testing.T) {
 	db := postgrestest.DBTest(t)
 
-	err := db.Pool.Ping(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := db.Pool.Ping(ctx)
 	if err != nil {
 		t.Fatalf("db error: %s", err)
 	}

--- a/bean/internal/driver/postgres/postgrestest/postgrestest.go
+++ b/bean/internal/driver/postgres/postgrestest/postgrestest.go
@@ -1,8 +1,10 @@
 package postgrestest
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/driver/postgres"
 )
@@ -14,7 +16,10 @@ func DBTest(t *testing.T) *postgres.DB {
 		t.Skip("skipping integration test, set env var INTEGRATION=1")
 	}
 
-	db, err := postgres.New(&postgres.DSNBuilder{
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	db, err := postgres.New(ctx, &postgres.DSNBuilder{
 		Host:     "postgres",
 		Port:     "5432",
 		Name:     "bean_test",

--- a/bean/internal/driver/redis/redis.go
+++ b/bean/internal/driver/redis/redis.go
@@ -19,7 +19,7 @@ type Cache struct {
 	Client *redis.Client
 }
 
-func New(cfg *Config) (*Cache, error) {
+func New(ctx context.Context, cfg *Config) (*Cache, error) {
 	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
 
 	client := redis.NewClient(
@@ -33,7 +33,7 @@ func New(cfg *Config) (*Cache, error) {
 		return nil, errors.New("error creating redis client")
 	}
 
-	err := client.Ping(context.Background()).Err()
+	err := client.Ping(ctx).Err()
 	if err != nil {
 		return nil, errors.New("error pinging redis: " + err.Error())
 	}

--- a/bean/internal/driver/redis/redis_test.go
+++ b/bean/internal/driver/redis/redis_test.go
@@ -3,6 +3,7 @@ package redis_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/driver/redis/redistest"
 )
@@ -10,7 +11,10 @@ import (
 func TestCache(t *testing.T) {
 	cache := redistest.CacheTest(t)
 
-	err := cache.Client.Ping(context.TODO()).Err()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := cache.Client.Ping(ctx).Err()
 	if err != nil {
 		t.Fatalf("cache error: %s", err)
 	}

--- a/bean/internal/driver/redis/redistest/redistest.go
+++ b/bean/internal/driver/redis/redistest/redistest.go
@@ -1,8 +1,10 @@
 package redistest
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/driver/redis"
 )
@@ -14,7 +16,10 @@ func CacheTest(t *testing.T) *redis.Cache {
 		t.Skip("skipping integration test, set env var INTEGRATION=1")
 	}
 
-	cache, err := redis.New(&redis.Config{
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cache, err := redis.New(ctx, &redis.Config{
 		Host:     "redis",
 		Port:     "6379",
 		Username: "default",


### PR DESCRIPTION
Starts to actually use contexts properly

Passes down a context to the DB and cache

Also replaces previous `context.TODO`s

Testing instructions:
1. Run

  ```
  > dc exec -e INTEGRATION=1 bean go test ./...
  ```
  
1. Ensure there's no fails