### PR TITLE
bean: Pass down context to memberships ds

### DIFF
--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -26,7 +26,9 @@ type Controller struct {
 
 func (c *Controller) HomePage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
+
+		session := auth.SessionFromContext(ctx)
 
 		methods, err := c.PaymentMethods.List(session.UserID)
 		if err != nil {
@@ -59,9 +61,11 @@ func (c *Controller) HomePage() http.HandlerFunc {
 
 func (c *Controller) RenewPlanPage() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		isMember, _ := c.Memberships.CheckByID(session.UserID)
+		session := auth.SessionFromContext(ctx)
+
+		isMember, _ := c.Memberships.CheckByID(ctx, session.UserID)
 		if isMember {
 			http.Redirect(w, r, "/home", http.StatusFound)
 			return

--- a/bean/internal/adapter/controller/auth/membership.go
+++ b/bean/internal/adapter/controller/auth/membership.go
@@ -7,9 +7,11 @@ import (
 
 func (c *Controller) CheckMembership(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		session := SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		isMember, err := c.Memberships.CheckByID(session.UserID)
+		session := SessionFromContext(ctx)
+
+		isMember, err := c.Memberships.CheckByID(ctx, session.UserID)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/driver/datasource/membership/membership.go
+++ b/bean/internal/driver/datasource/membership/membership.go
@@ -20,12 +20,16 @@ func New(db *postgres.DB) interfaces.MembershipDataSource {
 	return &dataSource{db}
 }
 
-func (ds *dataSource) Create(userID string, createdAt time.Time) (*model.Membership, error) {
+func (ds *dataSource) Create(
+	ctx context.Context,
+	userID string,
+	createdAt time.Time,
+) (*model.Membership, error) {
 	membership := &model.Membership{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("INSERT INTO memberships"+
 				" (user_id, created_at)"+
 				" VALUES ($1, $2)"+
@@ -48,12 +52,15 @@ func (ds *dataSource) Create(userID string, createdAt time.Time) (*model.Members
 	return membership, nil
 }
 
-func (ds *dataSource) Find(userID string) (*model.Membership, error) {
+func (ds *dataSource) Find(
+	ctx context.Context,
+	userID string,
+) (*model.Membership, error) {
 	membership := &model.Membership{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("SELECT * FROM memberships"+
 				" WHERE user_id = $1"),
 			userID,
@@ -74,12 +81,16 @@ func (ds *dataSource) Find(userID string) (*model.Membership, error) {
 	return membership, nil
 }
 
-func (ds *dataSource) Update(userID string, expiresAt time.Time) (*model.Membership, error) {
+func (ds *dataSource) Update(
+	ctx context.Context,
+	userID string,
+	expiresAt time.Time,
+) (*model.Membership, error) {
 	membership := &model.Membership{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("UPDATE memberships"+
 				" SET expires_at = $2"+
 				" WHERE user_id = $1"+
@@ -102,10 +113,13 @@ func (ds *dataSource) Update(userID string, expiresAt time.Time) (*model.Members
 	return membership, nil
 }
 
-func (ds *dataSource) Delete(userID string) error {
+func (ds *dataSource) Delete(
+	ctx context.Context,
+	userID string,
+) error {
 	_, err := ds.db.Pool.
 		Exec(
-			context.Background(),
+			ctx,
 			"DELETE FROM memberships WHERE user_id = $1",
 			userID,
 		)

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -1,6 +1,7 @@
 package interfaces
 
 import (
+	"context"
 	"time"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
@@ -59,13 +60,27 @@ type LoginTokenDataSource interface {
 }
 
 type MembershipDataSource interface {
-	Create(userID string, createdAt time.Time) (*model.Membership, error)
+	Create(
+		ctx context.Context,
+		userID string,
+		createdAt time.Time,
+	) (*model.Membership, error)
 
-	Find(userID string) (*model.Membership, error)
+	Find(
+		ctx context.Context,
+		userID string,
+	) (*model.Membership, error)
 
-	Update(userID string, expiresAt time.Time) (*model.Membership, error)
+	Update(
+		ctx context.Context,
+		userID string,
+		expiresAt time.Time,
+	) (*model.Membership, error)
 
-	Delete(userID string) error
+	Delete(
+		ctx context.Context,
+		userID string,
+	) error
 }
 
 type SessionDataSource interface {

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -1,6 +1,7 @@
 package membership
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -16,13 +17,17 @@ type UseCase struct {
 	Memberships interfaces.MembershipDataSource
 }
 
-func (u *UseCase) Create(email string, createdAt time.Time) (*model.Membership, error) {
+func (u *UseCase) Create(
+	ctx context.Context,
+	email string,
+	createdAt time.Time,
+) (*model.Membership, error) {
 	user, err := u.findOrCreateUser(email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or create user: %v", err)
 	}
 
-	membership, err := u.Memberships.Create(user.ID, createdAt)
+	membership, err := u.Memberships.Create(ctx, user.ID, createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create membership: %v", err)
 	}
@@ -30,7 +35,11 @@ func (u *UseCase) Create(email string, createdAt time.Time) (*model.Membership, 
 	return membership, nil
 }
 
-func (u *UseCase) Cancel(email string, expiresAt time.Time) (*model.Membership, error) {
+func (u *UseCase) Cancel(
+	ctx context.Context,
+	email string,
+	expiresAt time.Time,
+) (*model.Membership, error) {
 	user, err := u.Users.FindByEmail(email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user: %v", err)
@@ -40,7 +49,7 @@ func (u *UseCase) Cancel(email string, expiresAt time.Time) (*model.Membership, 
 		return nil, fmt.Errorf("user not found")
 	}
 
-	membership, err := u.Memberships.Update(user.ID, expiresAt)
+	membership, err := u.Memberships.Update(ctx, user.ID, expiresAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update membership: %v", err)
 	}
@@ -52,12 +61,15 @@ func (u *UseCase) Cancel(email string, expiresAt time.Time) (*model.Membership, 
 	return membership, nil
 }
 
-func (u *UseCase) CheckByID(userID string) (bool, error) {
+func (u *UseCase) CheckByID(
+	ctx context.Context,
+	userID string,
+) (bool, error) {
 	if u.Bypass {
 		return true, nil
 	}
 
-	membership, err := u.Memberships.Find(userID)
+	membership, err := u.Memberships.Find(ctx, userID)
 	if err != nil {
 		return false, fmt.Errorf("failed to find membership: %v", err)
 	}
@@ -73,7 +85,10 @@ func (u *UseCase) CheckByID(userID string) (bool, error) {
 	return true, nil
 }
 
-func (u *UseCase) CheckByEmail(email string) (bool, error) {
+func (u *UseCase) CheckByEmail(
+	ctx context.Context,
+	email string,
+) (bool, error) {
 	if u.Bypass {
 		return true, nil
 	}
@@ -87,7 +102,7 @@ func (u *UseCase) CheckByEmail(email string) (bool, error) {
 		return false, nil
 	}
 
-	return u.CheckByID(user.ID)
+	return u.CheckByID(ctx, user.ID)
 }
 
 func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {


### PR DESCRIPTION
Follow-up for #168 

Passes down context to the memberships ds 

This includes passing down the request context and updating tests

Testing instructions:
1. Run bean

  ```bash
  > dc up --build bean
  ```

2. Run all tests

  ```bash
  > dc exec -e INTEGRATION=1 bean go test ./...
  ```

3. Ensure membership data source tests pass