### PR TITLE
bean: Pass down context to paymentmethods ds

### DIFF
--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -30,7 +30,7 @@ func (c *Controller) HomePage() http.HandlerFunc {
 
 		session := auth.SessionFromContext(ctx)
 
-		methods, err := c.PaymentMethods.List(session.UserID)
+		methods, err := c.PaymentMethods.List(ctx, session.UserID)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/adapter/controller/app/paymentmethod/create.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/create.go
@@ -21,9 +21,12 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		form := getCreateFormData(r)
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
+
+		session := auth.SessionFromContext(ctx)
 
 		_, err := c.PaymentMethods.Create(
+			ctx,
 			session.UserID,
 			form.Label,
 			form.Last4,

--- a/bean/internal/adapter/controller/app/paymentmethod/delete.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/delete.go
@@ -18,9 +18,11 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 			return
 		}
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		pm, err := c.PaymentMethods.Get(session.UserID, id)
+		session := auth.SessionFromContext(ctx)
+
+		pm, err := c.PaymentMethods.Get(ctx, session.UserID, id)
 		if err != nil || pm == nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return
@@ -42,9 +44,11 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 			return
 		}
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		c.PaymentMethods.Delete(session.UserID, id)
+		session := auth.SessionFromContext(ctx)
+
+		c.PaymentMethods.Delete(ctx, session.UserID, id)
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	}

--- a/bean/internal/adapter/controller/app/subscription/create.go
+++ b/bean/internal/adapter/controller/app/subscription/create.go
@@ -27,9 +27,12 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		form := getCreateFormData(r)
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
+
+		session := auth.SessionFromContext(ctx)
 
 		_, err := c.Subscriptions.Create(
+			ctx,
 			session.UserID,
 			form.PaymentMethodID,
 			form.Label,

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod.go
@@ -20,6 +20,7 @@ func New(db *postgres.DB) interfaces.PaymentMethodDataSource {
 }
 
 func (ds *dataSource) Create(
+	ctx context.Context,
 	userID string,
 	label string,
 	last4 string,
@@ -31,7 +32,7 @@ func (ds *dataSource) Create(
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("INSERT INTO payment_methods (user_id, label, last4, brand, exp_month, exp_year)"+
 				" VALUES ($1, $2, $3, $4, $5, $6)"+
 				" RETURNING *"),
@@ -50,10 +51,14 @@ func (ds *dataSource) Create(
 	return method, nil
 }
 
-func (ds *dataSource) FindByID(userID string, id string) (*model.PaymentMethodWithSubscriptions, error) {
+func (ds *dataSource) FindByID(
+	ctx context.Context,
+	userID string,
+	id string,
+) (*model.PaymentMethodWithSubscriptions, error) {
 	rows, err := ds.db.Pool.
 		Query(
-			context.Background(),
+			ctx,
 			("SELECT" +
 				" payment_methods.id, payment_methods.user_id," +
 				" payment_methods.label, payment_methods.last4, payment_methods.brand, payment_methods.exp_month, payment_methods.exp_year," +
@@ -129,10 +134,13 @@ func (ds *dataSource) FindByID(userID string, id string) (*model.PaymentMethodWi
 	}, nil
 }
 
-func (ds *dataSource) FindByUserID(userID string) ([]*model.PaymentMethodWithSubscriptions, error) {
+func (ds *dataSource) FindByUserID(
+	ctx context.Context,
+	userID string,
+) ([]*model.PaymentMethodWithSubscriptions, error) {
 	rows, err := ds.db.Pool.
 		Query(
-			context.Background(),
+			ctx,
 			("SELECT" +
 				" payment_methods.id, payment_methods.user_id," +
 				" payment_methods.label, payment_methods.last4, payment_methods.brand, payment_methods.exp_month, payment_methods.exp_year," +
@@ -222,10 +230,14 @@ func (ds *dataSource) FindByUserID(userID string) ([]*model.PaymentMethodWithSub
 	return methods, nil
 }
 
-func (ds *dataSource) Delete(userID string, id string) error {
+func (ds *dataSource) Delete(
+	ctx context.Context,
+	userID string,
+	id string,
+) error {
 	_, err := ds.db.Pool.
 		Exec(
-			context.Background(),
+			ctx,
 			"DELETE FROM payment_methods WHERE user_id = $1 AND id = $2",
 			userID, id,
 		)

--- a/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
+++ b/bean/internal/driver/datasource/paymentmethod/paymentmethod_test.go
@@ -1,7 +1,9 @@
 package paymentmethod
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 
@@ -40,7 +42,10 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
-	method, err := ds.Create(userWithMethodsID, "action-create", "1234", model.PaymentMethodBrandAmex, 12, 2024)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	method, err := ds.Create(ctx, userWithMethodsID, "action-create", "1234", model.PaymentMethodBrandAmex, 12, 2024)
 	if err != nil {
 		t.Fatalf("failed to create payment method: %s", err)
 	}
@@ -73,14 +78,17 @@ func create(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 		t.Errorf("expected expYear: %d, got: %d", 2024, method.ExpYear)
 	}
 
-	if err := ds.Delete(userWithMethodsID, method.ID); err != nil {
+	if err := ds.Delete(ctx, userWithMethodsID, method.ID); err != nil {
 		t.Fatalf("failed to cleanup payment method: %s", err)
 	}
 }
 
 func findByID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_payment_method", func(t *testing.T) {
-		method, err := ds.FindByID(userWithMethodsID, methodID)
+		method, err := ds.FindByID(ctx, userWithMethodsID, methodID)
 		if err != nil {
 			t.Fatalf("failed to find payment method by id: %s", err)
 		}
@@ -101,7 +109,7 @@ func findByID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	})
 
 	t.Run("not_own_payment_method", func(t *testing.T) {
-		method, err := ds.FindByID(userWithNoMethodsID, methodID)
+		method, err := ds.FindByID(ctx, userWithNoMethodsID, methodID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -112,7 +120,7 @@ func findByID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	})
 
 	t.Run("missing_payment_method", func(t *testing.T) {
-		method, err := ds.FindByID(userWithMethodsID, missingID)
+		method, err := ds.FindByID(ctx, userWithMethodsID, missingID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -124,8 +132,11 @@ func findByID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 }
 
 func findByUserID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("has_payment_methods", func(t *testing.T) {
-		methods, err := ds.FindByUserID(userWithMethodsID)
+		methods, err := ds.FindByUserID(ctx, userWithMethodsID)
 		if err != nil {
 			t.Fatalf("failed to find payment methods: %s", err)
 		}
@@ -152,7 +163,7 @@ func findByUserID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	})
 
 	t.Run("no_payment_methods", func(t *testing.T) {
-		methods, err := ds.FindByUserID(userWithNoMethodsID)
+		methods, err := ds.FindByUserID(ctx, userWithNoMethodsID)
 		if err != nil {
 			t.Fatalf("failed to find payment methods: %s", err)
 		}
@@ -164,17 +175,20 @@ func findByUserID(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 }
 
 func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_payment_method", func(t *testing.T) {
-		method, err := ds.Create(userWithMethodsID, "action-delete", "1234", model.PaymentMethodBrandAmex, 12, 2024)
+		method, err := ds.Create(ctx, userWithMethodsID, "action-delete", "1234", model.PaymentMethodBrandAmex, 12, 2024)
 		if err != nil {
 			t.Fatalf("failed to create payment method: %s", err)
 		}
 
-		if err = ds.Delete(userWithMethodsID, method.ID); err != nil {
+		if err = ds.Delete(ctx, userWithMethodsID, method.ID); err != nil {
 			t.Fatalf("failed to delete payment method: %s", err)
 		}
 
-		methodWithSubs, err := ds.FindByID(userWithMethodsID, method.ID)
+		methodWithSubs, err := ds.FindByID(ctx, userWithMethodsID, method.ID)
 		if err != nil {
 			t.Fatalf("failed to find payment method: %s", err)
 		}
@@ -185,11 +199,11 @@ func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	})
 
 	t.Run("not_own_payment_method", func(t *testing.T) {
-		if err := ds.Delete(userWithNoMethodsID, methodID); err != nil {
+		if err := ds.Delete(ctx, userWithNoMethodsID, methodID); err != nil {
 			t.Fatalf("failed to delete payment method: %s", err)
 		}
 
-		method, err := ds.FindByID(userWithMethodsID, methodID)
+		method, err := ds.FindByID(ctx, userWithMethodsID, methodID)
 		if err != nil {
 			t.Fatalf("failed to find payment method: %s", err)
 		}
@@ -200,7 +214,7 @@ func delete(t *testing.T, ds interfaces.PaymentMethodDataSource) {
 	})
 
 	t.Run("missing_payment_method", func(t *testing.T) {
-		if err := ds.Delete(userWithMethodsID, missingID); err != nil {
+		if err := ds.Delete(ctx, userWithMethodsID, missingID); err != nil {
 			t.Fatalf("failed to delete payment method: %s", err)
 		}
 	})

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -27,6 +27,7 @@ type SubscriptionDataSource interface {
 
 type PaymentMethodDataSource interface {
 	Create(
+		ctx context.Context,
 		userID string,
 		label string,
 		last4 string,
@@ -35,10 +36,21 @@ type PaymentMethodDataSource interface {
 		expYear int,
 	) (*model.PaymentMethod, error)
 
-	FindByID(userID string, id string) (*model.PaymentMethodWithSubscriptions, error)
-	FindByUserID(userID string) ([]*model.PaymentMethodWithSubscriptions, error)
+	FindByID(
+		ctx context.Context,
+		userID string,
+		id string,
+	) (*model.PaymentMethodWithSubscriptions, error)
+	FindByUserID(
+		ctx context.Context,
+		userID string,
+	) ([]*model.PaymentMethodWithSubscriptions, error)
 
-	Delete(userID string, id string) error
+	Delete(
+		ctx context.Context,
+		userID string,
+		id string,
+	) error
 }
 
 type UserDataSource interface {

--- a/bean/internal/usecase/paymentmethod/paymentmethod.go
+++ b/bean/internal/usecase/paymentmethod/paymentmethod.go
@@ -1,6 +1,7 @@
 package paymentmethod
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
@@ -13,6 +14,7 @@ type UseCase struct {
 }
 
 func (u *UseCase) Create(
+	ctx context.Context,
 	userID string,
 	label string,
 	last4 string,
@@ -40,7 +42,7 @@ func (u *UseCase) Create(
 		return nil, fmt.Errorf("invalid exp year: %w", err)
 	}
 
-	method, err := u.PaymentMethods.Create(userID, label, last4, brand, expMonth, expYear)
+	method, err := u.PaymentMethods.Create(ctx, userID, label, last4, brand, expMonth, expYear)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payment method: %w", err)
 	}
@@ -48,8 +50,12 @@ func (u *UseCase) Create(
 	return method, nil
 }
 
-func (u *UseCase) Get(userID string, paymentMethodID string) (*model.PaymentMethodWithSubscriptions, error) {
-	method, err := u.PaymentMethods.FindByID(userID, paymentMethodID)
+func (u *UseCase) Get(
+	ctx context.Context,
+	userID string,
+	paymentMethodID string,
+) (*model.PaymentMethodWithSubscriptions, error) {
+	method, err := u.PaymentMethods.FindByID(ctx, userID, paymentMethodID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment method: %w", err)
 	}
@@ -57,8 +63,11 @@ func (u *UseCase) Get(userID string, paymentMethodID string) (*model.PaymentMeth
 	return method, nil
 }
 
-func (u *UseCase) List(userID string) ([]*model.PaymentMethodWithSubscriptions, error) {
-	methods, err := u.PaymentMethods.FindByUserID(userID)
+func (u *UseCase) List(
+	ctx context.Context,
+	userID string,
+) ([]*model.PaymentMethodWithSubscriptions, error) {
+	methods, err := u.PaymentMethods.FindByUserID(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list payment methods: %w", err)
 	}
@@ -66,8 +75,12 @@ func (u *UseCase) List(userID string) ([]*model.PaymentMethodWithSubscriptions, 
 	return methods, nil
 }
 
-func (u *UseCase) Delete(userID string, paymentMethodID string) error {
-	if err := u.PaymentMethods.Delete(userID, paymentMethodID); err != nil {
+func (u *UseCase) Delete(
+	ctx context.Context,
+	userID string,
+	paymentMethodID string,
+) error {
+	if err := u.PaymentMethods.Delete(ctx, userID, paymentMethodID); err != nil {
 		return fmt.Errorf("failed to delete payment method: %w", err)
 	}
 

--- a/bean/internal/usecase/subscription/subscription.go
+++ b/bean/internal/usecase/subscription/subscription.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
@@ -14,6 +15,7 @@ type UseCase struct {
 }
 
 func (u *UseCase) Create(
+	ctx context.Context,
 	userID string,
 	paymentMethodID string,
 	label string,
@@ -42,7 +44,7 @@ func (u *UseCase) Create(
 		return nil, fmt.Errorf("invalid period: %w", err)
 	}
 
-	method, err := u.PaymentMethods.FindByID(userID, paymentMethodID)
+	method, err := u.PaymentMethods.FindByID(ctx, userID, paymentMethodID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment method: %w", err)
 	}


### PR DESCRIPTION
Follow-up for #169 

Passes down the context from resolvers

Also updates the tests accordingly

Testing instructions:
1. Run bean

    ```bash
    > dc up --build bean
    ```

1. Run all tests

    ```bash
    > dc exec -e INTEGRATION=1 bean go test ./...
    ```

1. Ensure membership data source tests pass