### PR TITLE
bean: Pass down context to subscriptions ds

### DIFF
--- a/bean/internal/adapter/controller/app/subscription/delete.go
+++ b/bean/internal/adapter/controller/app/subscription/delete.go
@@ -18,9 +18,11 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 			return
 		}
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		sub, err := c.Subscriptions.Get(session.UserID, subID)
+		session := auth.SessionFromContext(ctx)
+
+		sub, err := c.Subscriptions.Get(ctx, session.UserID, subID)
 		if err != nil || sub == nil {
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return
@@ -40,9 +42,11 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 			return
 		}
 
-		session := auth.SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		c.Subscriptions.Delete(session.UserID, subID)
+		session := auth.SessionFromContext(ctx)
+
+		c.Subscriptions.Delete(ctx, session.UserID, subID)
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	}

--- a/bean/internal/driver/datasource/subscription/subscription.go
+++ b/bean/internal/driver/datasource/subscription/subscription.go
@@ -22,6 +22,7 @@ func New(db *postgres.DB) interfaces.SubscriptionDataSource {
 }
 
 func (ds *dataSource) Create(
+	ctx context.Context,
 	userID string,
 	paymentMethodID string,
 	label string,
@@ -34,7 +35,7 @@ func (ds *dataSource) Create(
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("INSERT INTO subscriptions"+
 				" (user_id, payment_method_id, label, provider, amount, interval, period)"+
 				" VALUES ($1, $2, $3, $4, $5, $6, $7)"+
@@ -55,12 +56,16 @@ func (ds *dataSource) Create(
 	return sub, nil
 }
 
-func (ds *dataSource) FindByID(userID string, id string) (*model.Subscription, error) {
+func (ds *dataSource) FindByID(
+	ctx context.Context,
+	userID string,
+	id string,
+) (*model.Subscription, error) {
 	sub := &model.Subscription{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("SELECT * FROM subscriptions"+
 				" WHERE"+
 				" subscriptions.user_id = $1"+
@@ -85,10 +90,14 @@ func (ds *dataSource) FindByID(userID string, id string) (*model.Subscription, e
 	return sub, nil
 }
 
-func (ds *dataSource) Delete(userID string, id string) error {
+func (ds *dataSource) Delete(
+	ctx context.Context,
+	userID string,
+	id string,
+) error {
 	_, err := ds.db.Pool.
 		Exec(
-			context.Background(),
+			ctx,
 			"DELETE FROM subscriptions WHERE user_id = $1 AND id = $2",
 			userID, id,
 		)

--- a/bean/internal/driver/datasource/subscription/subscription_test.go
+++ b/bean/internal/driver/datasource/subscription/subscription_test.go
@@ -1,7 +1,9 @@
 package subscription
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 
@@ -38,7 +40,10 @@ func TestDataSouce(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
-	sub, err := ds.Create(userWithSubsID, methodID, "action-create", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	sub, err := ds.Create(ctx, userWithSubsID, methodID, "action-create", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
 	if err != nil {
 		t.Fatalf("failed to create subscription: %s", err)
 	}
@@ -75,14 +80,17 @@ func create(t *testing.T, ds interfaces.SubscriptionDataSource) {
 		t.Errorf("expected period: %s, got: %s", model.SubscriptionPeriodMonthly, sub.Period)
 	}
 
-	if err := ds.Delete(userWithSubsID, sub.ID); err != nil {
+	if err := ds.Delete(ctx, userWithSubsID, sub.ID); err != nil {
 		t.Fatalf("failed to cleanup subscription: %s", err)
 	}
 }
 
 func findByID(t *testing.T, ds interfaces.SubscriptionDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_subscription", func(t *testing.T) {
-		sub, err := ds.FindByID(userWithSubsID, subID)
+		sub, err := ds.FindByID(ctx, userWithSubsID, subID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -93,7 +101,7 @@ func findByID(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	})
 
 	t.Run("not_owned_subscription", func(t *testing.T) {
-		sub, err := ds.FindByID(userWithNoSubsID, subID)
+		sub, err := ds.FindByID(ctx, userWithNoSubsID, subID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -104,7 +112,7 @@ func findByID(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	})
 
 	t.Run("missing_subscription", func(t *testing.T) {
-		sub, err := ds.FindByID(userWithSubsID, missingID)
+		sub, err := ds.FindByID(ctx, userWithSubsID, missingID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -116,17 +124,20 @@ func findByID(t *testing.T, ds interfaces.SubscriptionDataSource) {
 }
 
 func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_subscription", func(t *testing.T) {
-		sub, err := ds.Create(userWithSubsID, methodID, "action-delete", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
+		sub, err := ds.Create(ctx, userWithSubsID, methodID, "action-delete", "bean", 1000, 1, model.SubscriptionPeriodMonthly)
 		if err != nil {
 			t.Fatalf("failed to create subscription: %s", err)
 		}
 
-		if err = ds.Delete(userWithSubsID, sub.ID); err != nil {
+		if err = ds.Delete(ctx, userWithSubsID, sub.ID); err != nil {
 			t.Fatalf("failed to delete subscription: %s", err)
 		}
 
-		sub, err = ds.FindByID(userWithSubsID, sub.ID)
+		sub, err = ds.FindByID(ctx, userWithSubsID, sub.ID)
 		if err != nil {
 			t.Fatalf("failed to find subscription: %s", err)
 		}
@@ -137,11 +148,11 @@ func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	})
 
 	t.Run("not_owned_subscription", func(t *testing.T) {
-		if err := ds.Delete(userWithNoSubsID, subID); err != nil {
+		if err := ds.Delete(ctx, userWithNoSubsID, subID); err != nil {
 			t.Errorf("failed to delete subscription: %s", err)
 		}
 
-		sub, err := ds.FindByID(userWithSubsID, subID)
+		sub, err := ds.FindByID(ctx, userWithSubsID, subID)
 		if err != nil {
 			t.Fatalf("failed to find subscription: %s", err)
 		}
@@ -152,7 +163,7 @@ func delete(t *testing.T, ds interfaces.SubscriptionDataSource) {
 	})
 
 	t.Run("missing_subscription", func(t *testing.T) {
-		if err := ds.Delete(userWithSubsID, missingID); err != nil {
+		if err := ds.Delete(ctx, userWithSubsID, missingID); err != nil {
 			t.Errorf("failed to delete subscription: %s", err)
 		}
 	})

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -11,6 +11,7 @@ import (
 
 type SubscriptionDataSource interface {
 	Create(
+		ctx context.Context,
 		userID string,
 		paymentMethodID string,
 		label string,
@@ -20,9 +21,17 @@ type SubscriptionDataSource interface {
 		period model.SubscriptionPeriod,
 	) (*model.Subscription, error)
 
-	FindByID(userID string, id string) (*model.Subscription, error)
+	FindByID(
+		ctx context.Context,
+		userID string,
+		id string,
+	) (*model.Subscription, error)
 
-	Delete(userID string, id string) error
+	Delete(
+		ctx context.Context,
+		userID string,
+		id string,
+	) error
 }
 
 type PaymentMethodDataSource interface {

--- a/bean/internal/usecase/subscription/subscription.go
+++ b/bean/internal/usecase/subscription/subscription.go
@@ -54,6 +54,7 @@ func (u *UseCase) Create(
 	}
 
 	subscription, err := u.Subscriptions.Create(
+		ctx,
 		userID,
 		paymentMethodID,
 		label,
@@ -69,8 +70,12 @@ func (u *UseCase) Create(
 	return subscription, nil
 }
 
-func (u *UseCase) Get(userID string, subscriptionID string) (*model.Subscription, error) {
-	subscription, err := u.Subscriptions.FindByID(userID, subscriptionID)
+func (u *UseCase) Get(
+	ctx context.Context,
+	userID string,
+	subscriptionID string,
+) (*model.Subscription, error) {
+	subscription, err := u.Subscriptions.FindByID(ctx, userID, subscriptionID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get subscription: %w", err)
 	}
@@ -78,8 +83,12 @@ func (u *UseCase) Get(userID string, subscriptionID string) (*model.Subscription
 	return subscription, nil
 }
 
-func (u *UseCase) Delete(userID string, subscriptionID string) error {
-	if err := u.Subscriptions.Delete(userID, subscriptionID); err != nil {
+func (u *UseCase) Delete(
+	ctx context.Context,
+	userID string,
+	subscriptionID string,
+) error {
+	if err := u.Subscriptions.Delete(ctx, userID, subscriptionID); err != nil {
 		return fmt.Errorf("failed to delete subscription: %w", err)
 	}
 


### PR DESCRIPTION
Follow-up for #170 

Passes down the context from resolvers

Also updates the tests accordingly

Testing instructions:
1. Run bean

    ```bash
    > dc up --build bean
    ```

1. Run all tests

    ```bash
    > dc exec -e INTEGRATION=1 bean go test ./...
    ```

1. Ensure data source tests pass