### PR TITLE
bean: Pass down context to tokens ds

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -62,7 +62,9 @@ func (c *Controller) Authorize() http.HandlerFunc {
 			return
 		}
 
-		sessionToken, err := c.Passwordless.Authorize(id, password)
+		ctx := r.Context()
+
+		sessionToken, err := c.Passwordless.Authorize(ctx, id, password)
 		if err != nil {
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return

--- a/bean/internal/adapter/controller/auth/login.go
+++ b/bean/internal/adapter/controller/auth/login.go
@@ -39,7 +39,9 @@ func (c *Controller) LoginForm() http.HandlerFunc {
 			return
 		}
 
-		err := c.Passwordless.Login(email)
+		ctx := r.Context()
+
+		err := c.Passwordless.Login(ctx, email)
 		if err != nil {
 			fmt.Fprintf(w, "Error: %v", err)
 			return

--- a/bean/internal/driver/buymeacoffee/buymeacoffee.go
+++ b/bean/internal/driver/buymeacoffee/buymeacoffee.go
@@ -110,7 +110,7 @@ func (c *Controller) membershipStarted(
 		return
 	}
 
-	err = c.Passwordless.Login(email)
+	err = c.Passwordless.Login(ctx, email)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/bean/internal/driver/datasource/token/token.go
+++ b/bean/internal/driver/datasource/token/token.go
@@ -21,12 +21,16 @@ func New(db *postgres.DB) interfaces.LoginTokenDataSource {
 	}
 }
 
-func (ds *dataSource) Create(email string, hashedToken string) (*model.LoginToken, error) {
+func (ds *dataSource) Create(
+	ctx context.Context,
+	email string,
+	hashedToken string,
+) (*model.LoginToken, error) {
 	token := &model.LoginToken{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("INSERT INTO login_tokens (email, hashed_token)"+
 				" VALUES ($1, $2)"+
 				" ON CONFLICT (email) DO UPDATE"+
@@ -43,12 +47,15 @@ func (ds *dataSource) Create(email string, hashedToken string) (*model.LoginToke
 	return token, nil
 }
 
-func (ds *dataSource) FindUnexpiredByEmail(email string) (*model.LoginToken, error) {
+func (ds *dataSource) FindUnexpiredByEmail(
+	ctx context.Context,
+	email string,
+) (*model.LoginToken, error) {
 	token := &model.LoginToken{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("SELECT * FROM login_tokens"+
 				" WHERE email = $1 AND expires_at > NOW()"),
 			email,
@@ -66,12 +73,15 @@ func (ds *dataSource) FindUnexpiredByEmail(email string) (*model.LoginToken, err
 	return token, nil
 }
 
-func (ds *dataSource) FindUnexpiredByID(id string) (*model.LoginToken, error) {
+func (ds *dataSource) FindUnexpiredByID(
+	ctx context.Context,
+	id string,
+) (*model.LoginToken, error) {
 	token := &model.LoginToken{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("SELECT * FROM login_tokens"+
 				" WHERE id = $1 AND expires_at > NOW()"),
 			id,
@@ -89,10 +99,13 @@ func (ds *dataSource) FindUnexpiredByID(id string) (*model.LoginToken, error) {
 	return token, nil
 }
 
-func (ds *dataSource) Delete(id string) error {
+func (ds *dataSource) Delete(
+	ctx context.Context,
+	id string,
+) error {
 	_, err := ds.db.Pool.
 		Exec(
-			context.Background(),
+			ctx,
 			"DELETE FROM login_tokens WHERE id = $1",
 			id,
 		)

--- a/bean/internal/driver/datasource/token/token_test.go
+++ b/bean/internal/driver/datasource/token/token_test.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -39,8 +40,11 @@ func TestDataSource(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.LoginTokenDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("new_token", func(t *testing.T) {
-		token, err := ds.Create("action-create", "hashed-token")
+		token, err := ds.Create(ctx, "action-create", "hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
@@ -49,18 +53,18 @@ func create(t *testing.T, ds interfaces.LoginTokenDataSource) {
 			t.Errorf("expected 10 minute expiry, got: %v", expiry)
 		}
 
-		if err = ds.Delete(token.ID); err != nil {
+		if err = ds.Delete(ctx, token.ID); err != nil {
 			t.Fatalf("failed to cleanup token: %s", err)
 		}
 	})
 
 	t.Run("existing_token", func(t *testing.T) {
-		old, err := ds.Create("action-overwrite", "old-hashed-token")
+		old, err := ds.Create(ctx, "action-overwrite", "old-hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
 
-		new, err := ds.Create("action-overwrite", "new-hashed-token")
+		new, err := ds.Create(ctx, "action-overwrite", "new-hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
@@ -81,20 +85,23 @@ func create(t *testing.T, ds interfaces.LoginTokenDataSource) {
 			t.Errorf("expected new hashed token, got: %s", old.HashedToken)
 		}
 
-		if err = ds.Delete(new.ID); err != nil {
+		if err = ds.Delete(ctx, new.ID); err != nil {
 			t.Fatalf("failed to cleanup token: %s", err)
 		}
 	})
 }
 
 func findUnexpiredByEmail(t *testing.T, ds interfaces.LoginTokenDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("valid_token", func(t *testing.T) {
-		token, err := ds.Create("action-find", "hashed-token")
+		token, err := ds.Create(ctx, "action-find", "hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
 
-		token, err = ds.FindUnexpiredByEmail(token.Email)
+		token, err = ds.FindUnexpiredByEmail(ctx, token.Email)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -103,13 +110,13 @@ func findUnexpiredByEmail(t *testing.T, ds interfaces.LoginTokenDataSource) {
 			t.Fatalf("expected token, got nil")
 		}
 
-		if err = ds.Delete(token.ID); err != nil {
+		if err = ds.Delete(ctx, token.ID); err != nil {
 			t.Fatalf("failed to cleanup token: %s", err)
 		}
 	})
 
 	t.Run("expired_token", func(t *testing.T) {
-		token, err := ds.FindUnexpiredByEmail(expiredEmail)
+		token, err := ds.FindUnexpiredByEmail(ctx, expiredEmail)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -120,7 +127,7 @@ func findUnexpiredByEmail(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	})
 
 	t.Run("missing_token", func(t *testing.T) {
-		token, err := ds.FindUnexpiredByEmail(missingEmail)
+		token, err := ds.FindUnexpiredByEmail(ctx, missingEmail)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -132,13 +139,16 @@ func findUnexpiredByEmail(t *testing.T, ds interfaces.LoginTokenDataSource) {
 }
 
 func findUnexpiredByID(t *testing.T, ds interfaces.LoginTokenDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("valid_token", func(t *testing.T) {
-		token, err := ds.Create("action-find", "hashed-token")
+		token, err := ds.Create(ctx, "action-find", "hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
 
-		token, err = ds.FindUnexpiredByID(token.ID)
+		token, err = ds.FindUnexpiredByID(ctx, token.ID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -147,13 +157,13 @@ func findUnexpiredByID(t *testing.T, ds interfaces.LoginTokenDataSource) {
 			t.Fatalf("expected token, got nil")
 		}
 
-		if err = ds.Delete(token.ID); err != nil {
+		if err = ds.Delete(ctx, token.ID); err != nil {
 			t.Fatalf("failed to cleanup token: %s", err)
 		}
 	})
 
 	t.Run("expired_token", func(t *testing.T) {
-		token, err := ds.FindUnexpiredByID(expiredID)
+		token, err := ds.FindUnexpiredByID(ctx, expiredID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -164,7 +174,7 @@ func findUnexpiredByID(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	})
 
 	t.Run("missing_token", func(t *testing.T) {
-		token, err := ds.FindUnexpiredByID(missingID)
+		token, err := ds.FindUnexpiredByID(ctx, missingID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -176,17 +186,20 @@ func findUnexpiredByID(t *testing.T, ds interfaces.LoginTokenDataSource) {
 }
 
 func delete(t *testing.T, ds interfaces.LoginTokenDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_token", func(t *testing.T) {
-		token, err := ds.Create("action-delete", "hashed-token")
+		token, err := ds.Create(ctx, "action-delete", "hashed-token")
 		if err != nil {
 			t.Fatalf("failed to create token: %s", err)
 		}
 
-		if err = ds.Delete(token.ID); err != nil {
+		if err = ds.Delete(ctx, token.ID); err != nil {
 			t.Fatalf("failed to delete token: %s", err)
 		}
 
-		token, err = ds.FindUnexpiredByID(token.ID)
+		token, err = ds.FindUnexpiredByID(ctx, token.ID)
 		if err != nil {
 			t.Fatalf("failed to find token: %s", err)
 		}
@@ -197,7 +210,7 @@ func delete(t *testing.T, ds interfaces.LoginTokenDataSource) {
 	})
 
 	t.Run("missing_token", func(t *testing.T) {
-		if err := ds.Delete(missingID); err != nil {
+		if err := ds.Delete(ctx, missingID); err != nil {
 			t.Fatalf("failed to delete token: %s", err)
 		}
 	})

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -72,12 +72,25 @@ type UserDataSource interface {
 }
 
 type LoginTokenDataSource interface {
-	Create(email string, hashedToken string) (*model.LoginToken, error)
+	Create(
+		ctx context.Context,
+		email string,
+		hashedToken string,
+	) (*model.LoginToken, error)
 
-	FindUnexpiredByEmail(email string) (*model.LoginToken, error)
-	FindUnexpiredByID(id string) (*model.LoginToken, error)
+	FindUnexpiredByEmail(
+		ctx context.Context,
+		email string,
+	) (*model.LoginToken, error)
+	FindUnexpiredByID(
+		ctx context.Context,
+		id string,
+	) (*model.LoginToken, error)
 
-	Delete(id string) error
+	Delete(
+		ctx context.Context,
+		id string,
+	) error
 }
 
 type MembershipDataSource interface {


### PR DESCRIPTION
Follow-up for #171

Passes down the context from resolvers

Also updates the tests accordingly

Testing instructions:
1. Run bean

    ```bash
    > dc up --build bean
    ```

1. Run all tests

    ```bash
    > dc exec -e INTEGRATION=1 bean go test ./...
    ```

1. Ensure data source tests pass