### PR TITLE
bean: Pass down context to users ds

### DIFF
--- a/bean/internal/driver/datasource/user/user.go
+++ b/bean/internal/driver/datasource/user/user.go
@@ -21,12 +21,15 @@ func New(db *postgres.DB) interfaces.UserDataSource {
 	}
 }
 
-func (ds *dataSource) Create(email string) (*model.User, error) {
+func (ds *dataSource) Create(
+	ctx context.Context,
+	email string,
+) (*model.User, error) {
 	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			("INSERT INTO users (email)"+
 				" VALUES ($1)"+
 				" RETURNING *"),
@@ -41,12 +44,15 @@ func (ds *dataSource) Create(email string) (*model.User, error) {
 	return user, nil
 }
 
-func (ds *dataSource) FindById(id string) (*model.User, error) {
+func (ds *dataSource) FindById(
+	ctx context.Context,
+	id string,
+) (*model.User, error) {
 	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			"SELECT * FROM users WHERE id = $1",
 			id,
 		).
@@ -63,12 +69,15 @@ func (ds *dataSource) FindById(id string) (*model.User, error) {
 	return user, nil
 }
 
-func (ds *dataSource) FindByEmail(email string) (*model.User, error) {
+func (ds *dataSource) FindByEmail(
+	ctx context.Context,
+	email string,
+) (*model.User, error) {
 	user := &model.User{}
 
 	err := ds.db.Pool.
 		QueryRow(
-			context.Background(),
+			ctx,
 			"SELECT * FROM users WHERE email = $1",
 			email,
 		).
@@ -85,10 +94,13 @@ func (ds *dataSource) FindByEmail(email string) (*model.User, error) {
 	return user, nil
 }
 
-func (ds *dataSource) Delete(id string) error {
+func (ds *dataSource) Delete(
+	ctx context.Context,
+	id string,
+) error {
 	_, err := ds.db.Pool.
 		Exec(
-			context.Background(),
+			ctx,
 			"DELETE FROM users WHERE id = $1",
 			id,
 		)

--- a/bean/internal/driver/datasource/user/user_test.go
+++ b/bean/internal/driver/datasource/user/user_test.go
@@ -1,7 +1,9 @@
 package user
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/whatis277/harvest/bean/internal/usecase/interfaces"
 
@@ -35,8 +37,11 @@ func TestDataSource(t *testing.T) {
 }
 
 func create(t *testing.T, ds interfaces.UserDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("new_user", func(t *testing.T) {
-		user, err := ds.Create("action-create")
+		user, err := ds.Create(ctx, "action-create")
 		if err != nil {
 			t.Fatalf("failed to create user: %s", err)
 		}
@@ -53,30 +58,33 @@ func create(t *testing.T, ds interfaces.UserDataSource) {
 			t.Error("expected creation time, got zero time")
 		}
 
-		if err = ds.Delete(user.ID); err != nil {
+		if err = ds.Delete(ctx, user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
 
 	t.Run("existing_user", func(t *testing.T) {
-		user, err := ds.Create("action-reject")
+		user, err := ds.Create(ctx, "action-reject")
 		if err != nil {
 			t.Fatalf("failed to create user: %s", err)
 		}
 
-		if _, err = ds.Create("action-reject"); err == nil {
+		if _, err = ds.Create(ctx, "action-reject"); err == nil {
 			t.Errorf("expected error, got nil")
 		}
 
-		if err = ds.Delete(user.ID); err != nil {
+		if err = ds.Delete(ctx, user.ID); err != nil {
 			t.Fatalf("failed to cleanup user: %s", err)
 		}
 	})
 }
 
 func findById(t *testing.T, ds interfaces.UserDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_user", func(t *testing.T) {
-		user, err := ds.FindById(userID)
+		user, err := ds.FindById(ctx, userID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -87,7 +95,7 @@ func findById(t *testing.T, ds interfaces.UserDataSource) {
 	})
 
 	t.Run("missing_user", func(t *testing.T) {
-		user, err := ds.FindById(missingID)
+		user, err := ds.FindById(ctx, missingID)
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -99,8 +107,11 @@ func findById(t *testing.T, ds interfaces.UserDataSource) {
 }
 
 func findByEmail(t *testing.T, ds interfaces.UserDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_user", func(t *testing.T) {
-		user, err := ds.FindByEmail("user-1")
+		user, err := ds.FindByEmail(ctx, "user-1")
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -111,7 +122,7 @@ func findByEmail(t *testing.T, ds interfaces.UserDataSource) {
 	})
 
 	t.Run("missing_user", func(t *testing.T) {
-		user, err := ds.FindByEmail("missing")
+		user, err := ds.FindByEmail(ctx, "missing")
 		if err != nil {
 			t.Fatalf("expected nil error, got: %s", err)
 		}
@@ -123,17 +134,20 @@ func findByEmail(t *testing.T, ds interfaces.UserDataSource) {
 }
 
 func delete(t *testing.T, ds interfaces.UserDataSource) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	t.Run("existing_user", func(t *testing.T) {
-		user, err := ds.Create("action-delete")
+		user, err := ds.Create(ctx, "action-delete")
 		if err != nil {
 			t.Fatalf("failed to create user: %s", err)
 		}
 
-		if err = ds.Delete(user.ID); err != nil {
+		if err = ds.Delete(ctx, user.ID); err != nil {
 			t.Fatalf("failed to delete user: %s", err)
 		}
 
-		user, err = ds.FindById(user.ID)
+		user, err = ds.FindById(ctx, user.ID)
 		if err != nil {
 			t.Fatalf("failed to find user: %s", err)
 		}
@@ -144,7 +158,7 @@ func delete(t *testing.T, ds interfaces.UserDataSource) {
 	})
 
 	t.Run("missing_user", func(t *testing.T) {
-		if err := ds.Delete(missingID); err != nil {
+		if err := ds.Delete(ctx, missingID); err != nil {
 			t.Fatalf("failed to delete user: %s", err)
 		}
 	})

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -63,12 +63,24 @@ type PaymentMethodDataSource interface {
 }
 
 type UserDataSource interface {
-	Create(email string) (*model.User, error)
+	Create(
+		ctx context.Context,
+		email string,
+	) (*model.User, error)
 
-	FindById(id string) (*model.User, error)
-	FindByEmail(email string) (*model.User, error)
+	FindById(
+		ctx context.Context,
+		id string,
+	) (*model.User, error)
+	FindByEmail(
+		ctx context.Context,
+		email string,
+	) (*model.User, error)
 
-	Delete(id string) error
+	Delete(
+		ctx context.Context,
+		id string,
+	) error
 }
 
 type LoginTokenDataSource interface {

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -22,7 +22,7 @@ func (u *UseCase) Create(
 	email string,
 	createdAt time.Time,
 ) (*model.Membership, error) {
-	user, err := u.findOrCreateUser(email)
+	user, err := u.findOrCreateUser(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or create user: %v", err)
 	}
@@ -40,7 +40,7 @@ func (u *UseCase) Cancel(
 	email string,
 	expiresAt time.Time,
 ) (*model.Membership, error) {
-	user, err := u.Users.FindByEmail(email)
+	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user: %v", err)
 	}
@@ -93,7 +93,7 @@ func (u *UseCase) CheckByEmail(
 		return true, nil
 	}
 
-	user, err := u.Users.FindByEmail(email)
+	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
 		return false, fmt.Errorf("failed to find user: %v", err)
 	}
@@ -105,8 +105,11 @@ func (u *UseCase) CheckByEmail(
 	return u.CheckByID(ctx, user.ID)
 }
 
-func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
-	user, err := u.Users.FindByEmail(email)
+func (u *UseCase) findOrCreateUser(
+	ctx context.Context,
+	email string,
+) (*model.User, error) {
+	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user: %w", err)
 	}
@@ -115,7 +118,7 @@ func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
 		return user, nil
 	}
 
-	user, err = u.Users.Create(email)
+	user, err = u.Users.Create(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -32,7 +32,7 @@ func (u *UseCase) Login(
 		return fmt.Errorf("failed to validate email: %w", err)
 	}
 
-	user, err := u.Users.FindByEmail(email)
+	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
 		return fmt.Errorf("failed to find user: %w", err)
 	}
@@ -90,7 +90,7 @@ func (u *UseCase) Authorize(
 		return nil, fmt.Errorf("failed to compare password: %w", err)
 	}
 
-	user, err := u.findOrCreateUser(token.Email)
+	user, err := u.findOrCreateUser(ctx, token.Email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or create user: %w", err)
 	}
@@ -146,8 +146,11 @@ func (u *UseCase) Logout(session *model.Session) error {
 	return nil
 }
 
-func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
-	user, err := u.Users.FindByEmail(email)
+func (u *UseCase) findOrCreateUser(
+	ctx context.Context,
+	email string,
+) (*model.User, error) {
+	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user: %w", err)
 	}
@@ -156,7 +159,7 @@ func (u *UseCase) findOrCreateUser(email string) (*model.User, error) {
 		return user, nil
 	}
 
-	user, err = u.Users.Create(email)
+	user, err = u.Users.Create(ctx, email)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}


### PR DESCRIPTION
Follow-up for #172

Passes down the context from resolvers

Also updates the tests accordingly

Testing instructions:
1. Run bean

    ```bash
    > dc up --build bean
    ```

1. Run all tests

    ```bash
    > dc exec -e INTEGRATION=1 bean go test ./...
    ```

1. Ensure data source tests pass