### PR TITLE
bean: Pass down context to sessions ds

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -28,7 +28,9 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 			return
 		}
 
-		session, err := c.Passwordless.Authenticate(sessionToken)
+		ctx := r.Context()
+
+		session, err := c.Passwordless.Authenticate(ctx, sessionToken)
 		if err != nil || session == nil {
 			c.cleanupSessionToken(w)
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
@@ -42,9 +44,9 @@ func (c *Controller) Authenticate(next http.Handler) http.HandlerFunc {
 			return
 		}
 
-		ctx := NewContextWithSession(r.Context(), session)
+		sessionCtx := NewContextWithSession(ctx, session)
 
-		next.ServeHTTP(w, r.WithContext(ctx))
+		next.ServeHTTP(w, r.WithContext(sessionCtx))
 	}
 }
 

--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -4,9 +4,11 @@ import "net/http"
 
 func (c *Controller) Logout() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		session := SessionFromContext(r.Context())
+		ctx := r.Context()
 
-		c.Passwordless.Logout(session)
+		session := SessionFromContext(ctx)
+
+		c.Passwordless.Logout(ctx, session)
 
 		c.cleanupSessionToken(w)
 

--- a/bean/internal/usecase/interfaces/interfaces.go
+++ b/bean/internal/usecase/interfaces/interfaces.go
@@ -130,13 +130,28 @@ type MembershipDataSource interface {
 }
 
 type SessionDataSource interface {
-	Create(userID string, hashedToken string, duration time.Duration) (*model.Session, error)
+	Create(
+		ctx context.Context,
+		userID string,
+		hashedToken string,
+		duration time.Duration,
+	) (*model.Session, error)
 
-	FindByID(id string) (*model.Session, error)
+	FindByID(
+		ctx context.Context,
+		id string,
+	) (*model.Session, error)
 
-	Refresh(session *model.Session, duration time.Duration) error
+	Refresh(
+		ctx context.Context,
+		session *model.Session,
+		duration time.Duration,
+	) error
 
-	Delete(id string) error
+	Delete(
+		ctx context.Context,
+		id string,
+	) error
 }
 
 // --- Misc ---

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -100,7 +100,7 @@ func (u *UseCase) Authorize(
 		return nil, fmt.Errorf("failed to generate password: %w", err)
 	}
 
-	session, err := u.Sessions.Create(user.ID, csrfHash, 14*24*time.Hour)
+	session, err := u.Sessions.Create(ctx, user.ID, csrfHash, 14*24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
@@ -116,8 +116,11 @@ func (u *UseCase) Authorize(
 	return sessionToken, nil
 }
 
-func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session, error) {
-	session, err := u.Sessions.FindByID(sessionToken.ID)
+func (u *UseCase) Authenticate(
+	ctx context.Context,
+	sessionToken *model.SessionToken,
+) (*model.Session, error) {
+	session, err := u.Sessions.FindByID(ctx, sessionToken.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find session: %w", err)
 	}
@@ -130,7 +133,7 @@ func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session
 		return nil, fmt.Errorf("failed to compare session token: %w", err)
 	}
 
-	err = u.Sessions.Refresh(session, 14*24*time.Hour)
+	err = u.Sessions.Refresh(ctx, session, 14*24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh session: %w", err)
 	}
@@ -140,8 +143,11 @@ func (u *UseCase) Authenticate(sessionToken *model.SessionToken) (*model.Session
 	return session, nil
 }
 
-func (u *UseCase) Logout(session *model.Session) error {
-	u.Sessions.Delete(session.ID)
+func (u *UseCase) Logout(
+	ctx context.Context,
+	session *model.Session,
+) error {
+	u.Sessions.Delete(ctx, session.ID)
 
 	return nil
 }


### PR DESCRIPTION
Follow-up for #173

Passes down the context from resolvers

Also updates the tests accordingly

Testing instructions:
1. Run bean

    ```bash
    > dc up --build bean
    ```

1. Run all tests

    ```bash
    > dc exec -e INTEGRATION=1 bean go test ./...
    ```

1. Ensure data source tests pass