### PR TITLE
bean: Fix nil ctx session handling

### DIFF
--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -29,6 +29,10 @@ func (c *Controller) HomePage() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		methods, err := c.PaymentMethods.List(ctx, session.UserID)
 		if err != nil {
@@ -64,6 +68,10 @@ func (c *Controller) RenewPlanPage() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		isMember, _ := c.Memberships.CheckByID(ctx, session.UserID)
 		if isMember {

--- a/bean/internal/adapter/controller/app/paymentmethod/create.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/create.go
@@ -24,6 +24,10 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		_, err := c.PaymentMethods.Create(
 			ctx,

--- a/bean/internal/adapter/controller/app/paymentmethod/delete.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/delete.go
@@ -21,6 +21,10 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		pm, err := c.PaymentMethods.Get(ctx, session.UserID, id)
 		if err != nil || pm == nil {
@@ -47,6 +51,10 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		c.PaymentMethods.Delete(ctx, session.UserID, id)
 

--- a/bean/internal/adapter/controller/app/subscription/create.go
+++ b/bean/internal/adapter/controller/app/subscription/create.go
@@ -30,6 +30,10 @@ func (c *Controller) CreateForm() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		_, err := c.Subscriptions.Create(
 			ctx,

--- a/bean/internal/adapter/controller/app/subscription/delete.go
+++ b/bean/internal/adapter/controller/app/subscription/delete.go
@@ -21,6 +21,10 @@ func (c *Controller) DeletePage() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		sub, err := c.Subscriptions.Get(ctx, session.UserID, subID)
 		if err != nil || sub == nil {
@@ -45,6 +49,10 @@ func (c *Controller) DeleteForm() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := auth.SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		c.Subscriptions.Delete(ctx, session.UserID, subID)
 

--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -7,11 +7,12 @@ func (c *Controller) Logout() http.HandlerFunc {
 		ctx := r.Context()
 
 		session := SessionFromContext(ctx)
-
-		c.Passwordless.Logout(ctx, session)
+		if session != nil {
+			c.Passwordless.Logout(ctx, session)
+		}
 
 		c.cleanupSessionToken(w)
 
-		http.Redirect(w, r, "/", http.StatusSeeOther)
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
 	}
 }

--- a/bean/internal/adapter/controller/auth/membership.go
+++ b/bean/internal/adapter/controller/auth/membership.go
@@ -10,6 +10,10 @@ func (c *Controller) CheckMembership(next http.Handler) http.HandlerFunc {
 		ctx := r.Context()
 
 		session := SessionFromContext(ctx)
+		if session == nil {
+			http.Redirect(w, r, "/logout", http.StatusFound)
+			return
+		}
 
 		isMember, err := c.Memberships.CheckByID(ctx, session.UserID)
 		if err != nil {

--- a/bean/internal/adapter/controller/auth/session.go
+++ b/bean/internal/adapter/controller/auth/session.go
@@ -15,6 +15,10 @@ func NewContextWithSession(ctx context.Context, session *model.Session) context.
 }
 
 func SessionFromContext(ctx context.Context) *model.Session {
-	session, _ := ctx.Value(sessionContextKey).(*model.Session)
+	session, ok := ctx.Value(sessionContextKey).(*model.Session)
+	if !ok {
+		return nil
+	}
+
 	return session
 }


### PR DESCRIPTION
Starts checking if ctx session is nil or not 

If it's nil, redirects to `/logout`

`/logout` is an authenticated endpoint
So if there's a cookie and no session, cookie gets cleared

If there's a session but a problem fetching it, cookie also gets cleared
If there's a session and no problem fetching it, cookie also gets cleared

Whichever 🤷🏼 

Testing instructions:
1. Just go through the general flow from the README
