### PR TITLE
bean: Improve user input error handling

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -44,7 +44,7 @@ func main() {
 	env, err := envAdapter.New()
 	if err != nil {
 		panic(
-			fmt.Errorf("error reading env: %v", err),
+			fmt.Errorf("error reading env: %w", err),
 		)
 	}
 
@@ -61,7 +61,7 @@ func main() {
 	})
 	if err != nil {
 		panic(
-			fmt.Errorf("error connecting db: %v", err),
+			fmt.Errorf("error connecting db: %w", err),
 		)
 	}
 	defer db.Close()
@@ -77,7 +77,7 @@ func main() {
 	})
 	if err != nil {
 		panic(
-			fmt.Errorf("error connecting cache: %v", err),
+			fmt.Errorf("error connecting cache: %w", err),
 		)
 	}
 	defer cache.Close()
@@ -126,63 +126,63 @@ func main() {
 	landingView, err := landingVD.New(template.FS, template.LandingTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating landing view: %v", err),
+			fmt.Errorf("error creating landing view: %w", err),
 		)
 	}
 
 	loginView, err := authVD.NewLogin(template.FS, template.LoginTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating login view: %v", err),
+			fmt.Errorf("error creating login view: %w", err),
 		)
 	}
 
 	signUpView, err := authVD.NewSignup(template.FS, template.SignUpTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating signup view: %v", err),
+			fmt.Errorf("error creating signup view: %w", err),
 		)
 	}
 
 	homeView, err := appVD.NewHome(template.FS, template.HomeTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating home view: %v", err),
+			fmt.Errorf("error creating home view: %w", err),
 		)
 	}
 
 	renewPlanView, err := appVD.NewRenewPlan(template.FS, template.RenewPlanTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating renew plan view: %v", err),
+			fmt.Errorf("error creating renew plan view: %w", err),
 		)
 	}
 
 	createPaymentMethodView, err := paymentMethodVD.NewCreate(template.FS, template.CreatePaymentMethodTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating create payment method view: %v", err),
+			fmt.Errorf("error creating create payment method view: %w", err),
 		)
 	}
 
 	deletePaymentMethodView, err := paymentMethodVD.NewDelete(template.FS, template.DeletePaymentMethodTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating delete payment method view: %v", err),
+			fmt.Errorf("error creating delete payment method view: %w", err),
 		)
 	}
 
 	createSubscriptionView, err := subscriptionVD.NewCreate(template.FS, template.CreateSubscriptionTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating create subscription view: %v", err),
+			fmt.Errorf("error creating create subscription view: %w", err),
 		)
 	}
 
 	deleteSubscriptionView, err := subscriptionVD.NewDelete(template.FS, template.DeleteSubscriptionTemplate)
 	if err != nil {
 		panic(
-			fmt.Errorf("error creating delete subscription view: %v", err),
+			fmt.Errorf("error creating delete subscription view: %w", err),
 		)
 	}
 

--- a/bean/internal/adapter/controller/app/app.go
+++ b/bean/internal/adapter/controller/app/app.go
@@ -37,7 +37,6 @@ func (c *Controller) HomePage() base.HTTPHandler {
 
 		methods, err := c.PaymentMethods.List(ctx, session.UserID)
 		if err != nil {
-			// FIXME: This should check for a specific error type
 			return &base.HTTPError{
 				Status: http.StatusInternalServerError,
 

--- a/bean/internal/adapter/controller/app/paymentmethod/create.go
+++ b/bean/internal/adapter/controller/app/paymentmethod/create.go
@@ -40,12 +40,28 @@ func (c *Controller) CreateForm() base.HTTPHandler {
 			form.ExpYear,
 		)
 
-		if err != nil {
-			// FIXME: This should check for a specific error type
+		switch err.(type) {
+		case nil:
+			break
+
+		case model.UserInputError:
 			return c.renderCreateView(w, &viewmodel.CreatePaymentMethodViewData{
 				Error: err.Error(),
 				Form:  form,
 			})
+
+		default:
+			renderErr := c.renderCreateView(w, &viewmodel.CreatePaymentMethodViewData{
+				Error: "Something went wrong",
+				Form:  form,
+			})
+			return &base.HTTPError{
+				Message: fmt.Sprintf(
+					("pms: create: error creating payment method: %v |" +
+						" pms: create: error rendering view: %v"),
+					err, renderErr,
+				),
+			}
 		}
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)

--- a/bean/internal/adapter/controller/app/subscription/create.go
+++ b/bean/internal/adapter/controller/app/subscription/create.go
@@ -51,12 +51,28 @@ func (c *Controller) CreateForm() base.HTTPHandler {
 			model.SubscriptionPeriod(form.Period),
 		)
 
-		if err != nil {
-			// FIXME: This should check for a specific error type
+		switch err.(type) {
+		case nil:
+			break
+
+		case model.UserInputError:
 			return c.renderCreateView(w, &viewmodel.CreateSubscriptionViewData{
 				Error: err.Error(),
 				Form:  form,
 			})
+
+		default:
+			renderErr := c.renderCreateView(w, &viewmodel.CreateSubscriptionViewData{
+				Error: "Something went wrong",
+				Form:  form,
+			})
+			return &base.HTTPError{
+				Message: fmt.Sprintf(
+					("subs: create: error creating subscription: %v |" +
+						" subs: create: error rendering view: %v"),
+					err, renderErr,
+				),
+			}
 		}
 
 		http.Redirect(w, r, "/home", http.StatusSeeOther)

--- a/bean/internal/adapter/controller/app/subscription/delete.go
+++ b/bean/internal/adapter/controller/app/subscription/delete.go
@@ -29,7 +29,6 @@ func (c *Controller) DeletePage() base.HTTPHandler {
 
 		sub, err := c.Subscriptions.Get(ctx, session.UserID, subID)
 		if err != nil {
-			// FIXME: This should check for a specific error type
 			http.Redirect(w, r, "/home", http.StatusSeeOther)
 			return &base.HTTPError{
 				Message: fmt.Sprintf(

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -34,7 +34,6 @@ func (c *Controller) Authenticate(next base.HTTPHandler) base.HTTPHandler {
 		session, err := c.Passwordless.Authenticate(ctx, sessionToken)
 		if err != nil {
 			UnauthedUserRedirect(w, r)
-			// FIXME: This should check for a specific error type
 			return &base.HTTPError{
 				Message: fmt.Sprintf(
 					"auth: authenticate: error authenticating user: %v",
@@ -79,7 +78,6 @@ func (c *Controller) Authorize() base.HTTPHandler {
 		sessionToken, err := c.Passwordless.Authorize(ctx, id, password)
 		if err != nil {
 			UnauthedUserRedirect(w, r)
-			// FIXME: This should check for a specific error type
 			return &base.HTTPError{
 				Message: fmt.Sprintf(
 					"auth: authorize: error authorizing user: %v",

--- a/bean/internal/adapter/controller/auth/membership.go
+++ b/bean/internal/adapter/controller/auth/membership.go
@@ -19,7 +19,6 @@ func (c *Controller) CheckMembership(next base.HTTPHandler) base.HTTPHandler {
 
 		isMember, err := c.Memberships.CheckByID(ctx, session.UserID)
 		if err != nil {
-			// FIXME: This should check for a specific error type
 			return &base.HTTPError{
 				Status: http.StatusInternalServerError,
 

--- a/bean/internal/adapter/controller/base/base.go
+++ b/bean/internal/adapter/controller/base/base.go
@@ -19,6 +19,7 @@ func (c *Controller) ErrorHandler(
 		switch e := err.(type) {
 		case *HTTPError:
 			handleHTTPError(w, r, e)
+
 		default:
 			handleGenericError(w, r, e)
 		}

--- a/bean/internal/driver/buymeacoffee/buymeacoffee.go
+++ b/bean/internal/driver/buymeacoffee/buymeacoffee.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/whatis277/harvest/bean/internal/entity/model"
 	"github.com/whatis277/harvest/bean/internal/usecase/membership"
 	"github.com/whatis277/harvest/bean/internal/usecase/passwordless"
 
@@ -156,7 +157,21 @@ func (c *Controller) membershipStarted(
 	}
 
 	err = c.Passwordless.Login(ctx, email)
-	if err != nil {
+	switch err.(type) {
+	case nil:
+		break
+
+	case model.UserInputError:
+		return &base.HTTPError{
+			Status: http.StatusBadRequest,
+
+			Message: fmt.Sprintf(
+				"buymeacoffee: webhook: error logging in user: %v",
+				err,
+			),
+		}
+
+	default:
 		return &base.HTTPError{
 			Status: http.StatusInternalServerError,
 

--- a/bean/internal/driver/buymeacoffee/buymeacoffee.go
+++ b/bean/internal/driver/buymeacoffee/buymeacoffee.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/whatis277/harvest/bean/internal/entity/model"
+
 	"github.com/whatis277/harvest/bean/internal/usecase/membership"
 	"github.com/whatis277/harvest/bean/internal/usecase/passwordless"
 

--- a/bean/internal/entity/model/model.go
+++ b/bean/internal/entity/model/model.go
@@ -137,6 +137,12 @@ func (s *SessionToken) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, s)
 }
 
+// --- Error ---
+
+// --- Error --- User Input ---
+
+type UserInputError error
+
 // --- Misc ---
 
 type Estimates struct {

--- a/bean/internal/usecase/membership/membership.go
+++ b/bean/internal/usecase/membership/membership.go
@@ -24,12 +24,12 @@ func (u *UseCase) Create(
 ) (*model.Membership, error) {
 	user, err := u.findOrCreateUser(ctx, email)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find or create user: %v", err)
+		return nil, fmt.Errorf("failed to find or create user: %w", err)
 	}
 
 	membership, err := u.Memberships.Create(ctx, user.ID, createdAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create membership: %v", err)
+		return nil, fmt.Errorf("failed to create membership: %w", err)
 	}
 
 	return membership, nil
@@ -42,7 +42,7 @@ func (u *UseCase) Cancel(
 ) (*model.Membership, error) {
 	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find user: %v", err)
+		return nil, fmt.Errorf("failed to find user: %w", err)
 	}
 
 	if user == nil {
@@ -51,7 +51,7 @@ func (u *UseCase) Cancel(
 
 	membership, err := u.Memberships.Update(ctx, user.ID, expiresAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update membership: %v", err)
+		return nil, fmt.Errorf("failed to update membership: %w", err)
 	}
 
 	if membership == nil {
@@ -71,7 +71,7 @@ func (u *UseCase) CheckByID(
 
 	membership, err := u.Memberships.Find(ctx, userID)
 	if err != nil {
-		return false, fmt.Errorf("failed to find membership: %v", err)
+		return false, fmt.Errorf("failed to find membership: %w", err)
 	}
 
 	if membership == nil {
@@ -95,7 +95,7 @@ func (u *UseCase) CheckByEmail(
 
 	user, err := u.Users.FindByEmail(ctx, email)
 	if err != nil {
-		return false, fmt.Errorf("failed to find user: %v", err)
+		return false, fmt.Errorf("failed to find user: %w", err)
 	}
 
 	if user == nil {

--- a/bean/internal/usecase/passwordless/validation.go
+++ b/bean/internal/usecase/passwordless/validation.go
@@ -3,9 +3,11 @@ package passwordless
 import (
 	"fmt"
 	"net/mail"
+
+	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
-func validateEmail(email string) error {
+func validateEmail(email string) model.UserInputError {
 	if len(email) < 3 {
 		return fmt.Errorf("email must be greater than 2 chars")
 	}

--- a/bean/internal/usecase/paymentmethod/validation.go
+++ b/bean/internal/usecase/paymentmethod/validation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
-func validateLabel(label string) error {
+func validateLabel(label string) model.UserInputError {
 	if len(label) > 255 {
 		return fmt.Errorf("label must be less than 255 chars")
 	}
@@ -15,7 +15,7 @@ func validateLabel(label string) error {
 	return nil
 }
 
-func validateLast4(last4 string) error {
+func validateLast4(last4 string) model.UserInputError {
 	pattern, err := regexp.Compile(`^\d{4}$`)
 	if err != nil {
 		return fmt.Errorf("failed to compile regex: %w", err)
@@ -28,7 +28,7 @@ func validateLast4(last4 string) error {
 	return nil
 }
 
-func validateBrand(brand model.PaymentMethodBrand) error {
+func validateBrand(brand model.PaymentMethodBrand) model.UserInputError {
 	switch brand {
 	case model.PaymentMethodBrandAmex,
 		model.PaymentMethodBrandMastercard,
@@ -44,7 +44,7 @@ func validateBrand(brand model.PaymentMethodBrand) error {
 	}
 }
 
-func validateExpMonth(expMonth int) error {
+func validateExpMonth(expMonth int) model.UserInputError {
 	if expMonth < 1 {
 		return fmt.Errorf("exp month must be greater than 0")
 	}
@@ -56,7 +56,7 @@ func validateExpMonth(expMonth int) error {
 	return nil
 }
 
-func validateExpYear(expYear int) error {
+func validateExpYear(expYear int) model.UserInputError {
 	if expYear < 2000 {
 		return fmt.Errorf("exp year must be greater than 2000")
 	}

--- a/bean/internal/usecase/subscription/validation.go
+++ b/bean/internal/usecase/subscription/validation.go
@@ -6,7 +6,7 @@ import (
 	"github.com/whatis277/harvest/bean/internal/entity/model"
 )
 
-func validateLabel(label string) error {
+func validateLabel(label string) model.UserInputError {
 	if len(label) > 255 {
 		return fmt.Errorf("label must be less than 255 chars")
 	}
@@ -14,7 +14,7 @@ func validateLabel(label string) error {
 	return nil
 }
 
-func validateProvider(provider string) error {
+func validateProvider(provider string) model.UserInputError {
 	if len(provider) > 255 {
 		return fmt.Errorf("provider must be less than 255 chars")
 	}
@@ -22,7 +22,7 @@ func validateProvider(provider string) error {
 	return nil
 }
 
-func validateAmount(amount int) error {
+func validateAmount(amount int) model.UserInputError {
 	if amount <= 0 {
 		return fmt.Errorf("amount must be greater than 0")
 	}
@@ -30,7 +30,7 @@ func validateAmount(amount int) error {
 	return nil
 }
 
-func validateInterval(interval int) error {
+func validateInterval(interval int) model.UserInputError {
 	if interval <= 0 {
 		return fmt.Errorf("interval must be greater than 0")
 	}
@@ -42,7 +42,7 @@ func validateInterval(interval int) error {
 	return nil
 }
 
-func validatePeriod(period model.SubscriptionPeriod) error {
+func validatePeriod(period model.SubscriptionPeriod) model.UserInputError {
 	switch period {
 	case model.SubscriptionPeriodDaily,
 		model.SubscriptionPeriodWeekly,


### PR DESCRIPTION
Adds error wrapping where it should've been used

Differentiates between internal server errors and user input errors

No type was created for internal server errors because it's better to allow errors instead of restrict errors

Testing instructions:
1. Apply the following patch to ease testing

    ```diff
    diff --git a/bean/internal/driver/template/login.html b/bean/internal/driver/template/login.html
    index ecdcf48..b362262 100644
    --- a/bean/internal/driver/template/login.html
    +++ b/bean/internal/driver/template/login.html
    @@ -23,7 +23,7 @@
       <div class="subsection">
         <form name="login" method="post">
           <label for="email">Email</label>
    -      <input id="email" type="email" name="email" />
    +      <input id="email" type="text" name="email" />
           <input id="password" type="hidden" name="password" />
           <br />
           <input type="submit" value="Login" />
    
    ```

1. `dc up --build bean`

1. Visit http://whatisbean.local/login

1. Submit `aa` into the form

1. Ensure there's no error in the docker logs 

1. Apply the following patch now

    ```diff
    diff --git a/bean/internal/adapter/controller/auth/login.go b/bean/internal/adapter/controller/auth/login.go
    index d5049de..5eed9dc 100644
    --- a/bean/internal/adapter/controller/auth/login.go
    +++ b/bean/internal/adapter/controller/auth/login.go
    @@ -4,7 +4,6 @@ import (
            "fmt"
            "net/http"
     
    -       "github.com/whatis277/harvest/bean/internal/entity/model"
            "github.com/whatis277/harvest/bean/internal/entity/viewmodel"
     
            "github.com/whatis277/harvest/bean/internal/adapter/controller/base"
    @@ -44,7 +43,7 @@ func (c *Controller) LoginForm() base.HTTPHandler {
     
                    err := c.Passwordless.Login(ctx, email)
                    switch err.(type) {
    -               case nil, model.UserInputError:
    +               case nil:
                            return c.renderLogin(w, &viewmodel.LoginViewData{
                                    Email: email,
                            })
    
    ```

1. Submit `aa` into the form

1. Ensure there's an http error in the docker logs