### PR TITLE
bean: Improve silent error handling

### DIFF
--- a/bean/internal/adapter/controller/auth/logout.go
+++ b/bean/internal/adapter/controller/auth/logout.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/controller/base"
@@ -24,8 +25,30 @@ func (c *Controller) Logout() base.HTTPHandler {
 		c.cleanupSessionToken(w)
 
 		session := SessionFromContext(ctx)
-		if session != nil {
-			c.Passwordless.Logout(ctx, session)
+		if session == nil {
+			http.Redirect(
+				w,
+				r,
+				"/login",
+				defaultObscureStatus,
+			)
+			return nil
+		}
+
+		err := c.Passwordless.Logout(ctx, session)
+		if err != nil {
+			http.Redirect(
+				w,
+				r,
+				"/login",
+				defaultObscureStatus,
+			)
+			return &base.HTTPError{
+				Message: fmt.Sprintf(
+					"auth: logout: error logging out: %v",
+					err,
+				),
+			}
 		}
 
 		http.Redirect(

--- a/bean/internal/usecase/passwordless/passwordless.go
+++ b/bean/internal/usecase/passwordless/passwordless.go
@@ -83,7 +83,7 @@ func (u *UseCase) Authorize(
 	}
 
 	if token == nil {
-		return nil, fmt.Errorf("token not found")
+		return nil, nil
 	}
 
 	if err := u.Hasher.Compare(password, token.HashedToken); err != nil {
@@ -126,7 +126,7 @@ func (u *UseCase) Authenticate(
 	}
 
 	if session == nil {
-		return nil, fmt.Errorf("session not found")
+		return nil, nil
 	}
 
 	if err := u.Hasher.Compare(sessionToken.Token, session.HashedToken); err != nil {
@@ -147,7 +147,10 @@ func (u *UseCase) Logout(
 	ctx context.Context,
 	session *model.Session,
 ) error {
-	u.Sessions.Delete(ctx, session.ID)
+	err := u.Sessions.Delete(ctx, session.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete session: %w", err)
+	}
 
 	return nil
 }

--- a/bean/internal/usecase/subscription/subscription.go
+++ b/bean/internal/usecase/subscription/subscription.go
@@ -50,7 +50,7 @@ func (u *UseCase) Create(
 	}
 
 	if method == nil {
-		return nil, fmt.Errorf("payment method not found")
+		return nil, nil
 	}
 
 	subscription, err := u.Subscriptions.Create(


### PR DESCRIPTION
Stop returning an error for `nil` values after checking errors

Also modifies the logout to log the error message faced silently

Doesn't touch memberships though because those aren't user-inputted
They're added through the buymeacoffee website 
It's helpful to know when things aren't functioning as they should be

No testing needed