### PR TITLE
bean: Add session key to cache entries

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	tokenRepo := tokenDS.New(db)
 	userRepo := userDS.New(db)
-	sessionRepo := sessionDS.New(cache)
+	sessionRepo := sessionDS.New(cache, "session")
 	passwordlessAuth := passwordlessUC.UseCase{
 		Sender:   "Bean <support@whatisbean.com>",
 		BaseURL:  env.BaseURL,

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -71,7 +71,7 @@ func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
 			t.Errorf("expected expires at to be 10 seconds after created at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, session.ID).Val()
+		ttl := cache.Client.TTL(ctx, wrap(session.ID)).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -145,7 +145,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 10 seconds after updated at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, session.ID).Val()
+		ttl := cache.Client.TTL(ctx, wrap(session.ID)).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -160,7 +160,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 20 seconds after updated at, got: %s", duration)
 		}
 
-		ttl = cache.Client.TTL(ctx, session.ID).Val()
+		ttl = cache.Client.TTL(ctx, wrap(session.ID)).Val()
 		if ttl != 20*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 20*time.Second, ttl)
 		}

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -71,7 +71,7 @@ func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
 			t.Errorf("expected expires at to be 10 seconds after created at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, "test:"+session.ID).Val()
+		ttl := cache.TTL(ctx, "test", session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -145,7 +145,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 10 seconds after updated at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, "test:"+session.ID).Val()
+		ttl := cache.TTL(ctx, "test", session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -160,7 +160,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 20 seconds after updated at, got: %s", duration)
 		}
 
-		ttl = cache.Client.TTL(ctx, "test:"+session.ID).Val()
+		ttl = cache.TTL(ctx, "test", session.ID).Val()
 		if ttl != 20*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 20*time.Second, ttl)
 		}

--- a/bean/internal/driver/datasource/session/session_test.go
+++ b/bean/internal/driver/datasource/session/session_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDataSource(t *testing.T) {
 	cache := redistest.CacheTest(t)
-	ds := New(cache)
+	ds := New(cache, "test")
 
 	t.Run("create", func(t *testing.T) {
 		create(t, ds, cache)
@@ -71,7 +71,7 @@ func create(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) {
 			t.Errorf("expected expires at to be 10 seconds after created at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, wrap(session.ID)).Val()
+		ttl := cache.Client.TTL(ctx, "test:"+session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -145,7 +145,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 10 seconds after updated at, got: %s", duration)
 		}
 
-		ttl := cache.Client.TTL(ctx, wrap(session.ID)).Val()
+		ttl := cache.Client.TTL(ctx, "test:"+session.ID).Val()
 		if ttl != 10*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 10*time.Second, ttl)
 		}
@@ -160,7 +160,7 @@ func refresh(t *testing.T, ds interfaces.SessionDataSource, cache *redis.Cache) 
 			t.Errorf("expected expires at to be 20 seconds after updated at, got: %s", duration)
 		}
 
-		ttl = cache.Client.TTL(ctx, wrap(session.ID)).Val()
+		ttl = cache.Client.TTL(ctx, "test:"+session.ID).Val()
 		if ttl != 20*time.Second {
 			t.Errorf("expected session to expire in: %s, got: %s", 20*time.Second, ttl)
 		}

--- a/bean/internal/driver/redis/redis.go
+++ b/bean/internal/driver/redis/redis.go
@@ -17,7 +17,7 @@ type Config struct {
 }
 
 type Cache struct {
-	Client *redis.Client
+	client *redis.Client
 }
 
 func New(ctx context.Context, cfg *Config) (*Cache, error) {
@@ -40,12 +40,12 @@ func New(ctx context.Context, cfg *Config) (*Cache, error) {
 	}
 
 	return &Cache{
-		Client: client,
+		client: client,
 	}, nil
 }
 
 func (c *Cache) Close() {
-	c.Client.Close()
+	c.client.Close()
 }
 
 func (c *Cache) Set(
@@ -55,7 +55,7 @@ func (c *Cache) Set(
 	value interface{},
 	expiration time.Duration,
 ) *redis.StatusCmd {
-	return c.Client.Set(ctx, prefix(ns, key), value, expiration)
+	return c.client.Set(ctx, prefix(ns, key), value, expiration)
 }
 
 func (c *Cache) Get(
@@ -63,7 +63,7 @@ func (c *Cache) Get(
 	ns string,
 	key string,
 ) *redis.StringCmd {
-	return c.Client.Get(ctx, prefix(ns, key))
+	return c.client.Get(ctx, prefix(ns, key))
 }
 
 func (c *Cache) Del(
@@ -71,7 +71,15 @@ func (c *Cache) Del(
 	ns string,
 	key string,
 ) *redis.IntCmd {
-	return c.Client.Del(ctx, prefix(ns, key))
+	return c.client.Del(ctx, prefix(ns, key))
+}
+
+func (c *Cache) TTL(
+	ctx context.Context,
+	ns string,
+	key string,
+) *redis.DurationCmd {
+	return c.client.TTL(ctx, prefix(ns, key))
 }
 
 func prefix(namespace, key string) string {

--- a/bean/internal/driver/redis/redis.go
+++ b/bean/internal/driver/redis/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -43,6 +44,36 @@ func New(ctx context.Context, cfg *Config) (*Cache, error) {
 	}, nil
 }
 
-func (cache *Cache) Close() {
-	cache.Client.Close()
+func (c *Cache) Close() {
+	c.Client.Close()
+}
+
+func (c *Cache) Set(
+	ctx context.Context,
+	ns string,
+	key string,
+	value interface{},
+	expiration time.Duration,
+) *redis.StatusCmd {
+	return c.Client.Set(ctx, prefix(ns, key), value, expiration)
+}
+
+func (c *Cache) Get(
+	ctx context.Context,
+	ns string,
+	key string,
+) *redis.StringCmd {
+	return c.Client.Get(ctx, prefix(ns, key))
+}
+
+func (c *Cache) Del(
+	ctx context.Context,
+	ns string,
+	key string,
+) *redis.IntCmd {
+	return c.Client.Del(ctx, prefix(ns, key))
+}
+
+func prefix(namespace, key string) string {
+	return fmt.Sprintf("%s:%s", namespace, key)
 }

--- a/bean/internal/driver/redis/redis_test.go
+++ b/bean/internal/driver/redis/redis_test.go
@@ -14,17 +14,12 @@ func TestCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err := cache.Client.Ping(ctx).Err()
+	err := cache.Set(ctx, "test", "key", "value", 0).Err()
 	if err != nil {
 		t.Fatalf("cache error: %s", err)
 	}
 
-	err = cache.Client.Set(context.Background(), "key", "value", 0).Err()
-	if err != nil {
-		t.Fatalf("cache error: %s", err)
-	}
-
-	val, err := cache.Client.Get(context.Background(), "key").Result()
+	val, err := cache.Get(ctx, "test", "key").Result()
 	if err != nil {
 		t.Fatalf("cache error: %s", err)
 	}


### PR DESCRIPTION
Session entries were stored as `{uuid}` previously

Now they're stored as `session:{uuid}`

This helps namespace entries in a single app

Testing instructions:
1. `dc up bean`
2. `dc exec -e INTEGRATION=1 bean go test github.com/whatis277/harvest/bean/internal/driver/datasource/session  -v`