### PR TITLE
trellis: Add production related code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@
 !/go.sum
 !/go.mod
 
-# env example
-!**/.env.example
+# example files
+!**/*.example
 
 # go files
 !**/*.go
@@ -37,7 +37,9 @@
 # docker files
 !/docker-compose.yml
 !/docker-compose.override.yml
+!/docker-compose.prod.yml
 !*/docker/Dockerfile.dev
+!*/docker/Dockerfile.prod
 
 # tern migration files
 !*/config/*.tern.conf
@@ -46,5 +48,6 @@
 !*/config/.air.toml
 
 # trellis files
-!trellis/nginx.conf
-!trellis/services.dev/*.conf
+!/trellis/nginx.conf
+!/trellis/services.dev/*.conf
+!/trellis/services.prod/*.conf

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,8 +31,7 @@ services:
   
   trellis:
     build:
-      context: ./trellis
-      dockerfile: ./docker/Dockerfile.dev
+      dockerfile: ./trellis/docker/Dockerfile.dev
 
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+services:
+  bean:
+    image: whatis277/bean:1.0.0
+    build:
+      dockerfile: ./bean/docker/Dockerfile.prod
+    env_file:
+      - ./bean/config/.env.prod
+
+  trellis:
+    image: whatis277/trellis:1.0.0
+    build:
+      dockerfile: ./trellis/docker/Dockerfile.prod
+    volumes:
+      - certbot_etc:/etc/letsencrypt:ro
+
+  certbot:
+    image: certbot/certbot:v2.9.0
+    volumes:
+      - certbot_etc:/etc/letsencrypt:rw
+    env_file:
+      - ./trellis/config/.certbot.prod
+    entrypoint:
+      /bin/sh -c \
+        "certbot certonly \
+        --manual \
+        --preferred-challenges dns \
+        --keep-until-expiring \
+        --agree-tos \
+        --no-eff-email \
+        --email $$CERTBOT_EMAIL \
+        --domains $$CERTBOT_DOMAINS \
+        "
+
+volumes:
+  certbot_etc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - harvest
     ports:
       - "80:80"
+      - "443:443"
     healthcheck:
       test: ["CMD-SHELL", "service nginx status || exit 1"]
       interval: 10s

--- a/trellis/config/.certbot.example
+++ b/trellis/config/.certbot.example
@@ -1,0 +1,2 @@
+CERTBOT_EMAIL=
+CERTBOT_DOMAINS=whatisbean.com

--- a/trellis/docker/Dockerfile.prod
+++ b/trellis/docker/Dockerfile.prod
@@ -4,8 +4,10 @@ FROM nginx:1.25-alpine
 # copy nginx config
 COPY ./trellis/nginx.conf /etc/nginx/nginx.conf
 
-# copy dev services 
-COPY ./trellis/services.dev /etc/nginx/services
+# copy prod services 
+COPY ./trellis/services.prod /etc/nginx/services
 
 # expose port 80
 EXPOSE 80
+# expose port 443
+EXPOSE 443

--- a/trellis/services.prod/whatisbean.com.conf
+++ b/trellis/services.prod/whatisbean.com.conf
@@ -1,0 +1,30 @@
+server {
+  listen 80;
+  server_name whatisbean.com;
+
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+limit_req_zone $binary_remote_addr zone=bean_limit:10m rate=5r/s;
+
+server {
+  listen 443 ssl;
+  server_name whatisbean.com;
+
+  ssl_certificate /etc/letsencrypt/live/whatisbean.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/whatisbean.com/privkey.pem;
+
+  set $bean "http://bean:8080";
+
+  location / {
+    limit_req zone=bean_limit burst=10 nodelay;
+
+    proxy_pass $bean;
+  }
+}


### PR DESCRIPTION
Adds production Dockerfile

Adds certbot to production docker compose

Adds whatisbean.com service with SSL

Testing instructions:
1. Run certbot first

```bash
dc -f docker-compose.yml \
  -f docker-compose.prod.yml \
  run --rm certbot
```

1. Go through the DNS challenge manually

1. Run trellis

```bash
dc -f docker-compose.yml \
  -f docker-compose.prod.yml \
  up -d trellis
```

1. Navigate to https://whatisbean.com

1. Ensure the SSL certificate works

Other information:
I ran that using docker context. 

I rented a droplet on DigitalOcean.
Installed docker on the droplet using [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-22-04).

Set up docker context locally using:
```bash
docker context create \
  --docker "host=ssh://docker@<droplet-ip>" \
  --description "Harvest production server" \
  harvest
```

Then ran all the previous commands, but with:
```bash
docker -c harvest compose \
  -f docker-compose.yml \
  -f docker-compose.prod.yml \
  ...
```