### PR TITLE
bean: Fix missing tern port for prod

### DIFF
--- a/bean/config/migration.tern.conf
+++ b/bean/config/migration.tern.conf
@@ -1,5 +1,6 @@
 [database]
 host = {{env "DB_HOST"}}
+port = {{env "DB_PORT"}}
 database = {{env "DB_NAME"}}
 user = {{env "DB_USERNAME"}}
 password = {{env "DB_PASSWORD"}}

--- a/bean/config/seed.tern.conf
+++ b/bean/config/seed.tern.conf
@@ -1,5 +1,6 @@
 [database]
 host = {{env "DB_HOST"}}
+port = {{env "DB_PORT"}}
 database = {{env "DB_NAME"}}
 user = {{env "DB_USERNAME"}}
 password = {{env "DB_PASSWORD"}}


### PR DESCRIPTION
The tern config was missing the DB PORT

It's needed so we can run database migrations

No testing needed