### PR TITLE
bean: Add tern schema env var

### DIFF
--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -10,7 +10,7 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_SSL_MODE=disable
-DB_VERSION_TABLE=public.bean_schema_version
+DB_SCHEMA=public
 # cache
 CACHE_HOST=redis
 CACHE_PORT=6379

--- a/bean/config/.env.example
+++ b/bean/config/.env.example
@@ -10,6 +10,7 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_SSL_MODE=disable
+DB_VERSION_TABLE=public.bean_schema_version
 # cache
 CACHE_HOST=redis
 CACHE_PORT=6379

--- a/bean/config/migration.tern.conf
+++ b/bean/config/migration.tern.conf
@@ -5,4 +5,4 @@ database = {{env "DB_NAME"}}
 user = {{env "DB_USERNAME"}}
 password = {{env "DB_PASSWORD"}}
 sslmode = {{env "DB_SSL_MODE"}}
-version_table = {{env "DB_VERSION_TABLE"}}
+version_table = {{env "DB_SCHEMA"}}.bean_schema_version

--- a/bean/config/migration.tern.conf
+++ b/bean/config/migration.tern.conf
@@ -5,4 +5,4 @@ database = {{env "DB_NAME"}}
 user = {{env "DB_USERNAME"}}
 password = {{env "DB_PASSWORD"}}
 sslmode = {{env "DB_SSL_MODE"}}
-version_table = public.schema_version
+version_table = {{env "DB_VERSION_TABLE"}}

--- a/bean/config/seed.tern.conf
+++ b/bean/config/seed.tern.conf
@@ -5,4 +5,4 @@ database = {{env "DB_NAME"}}
 user = {{env "DB_USERNAME"}}
 password = {{env "DB_PASSWORD"}}
 sslmode = disable
-version_table = public.seed_version
+version_table = public.bean_seed_version


### PR DESCRIPTION
We don't want to use the public schema on production

So this env var allows us to modify the schema versions table

Testing instructions: 
* Run bean

```bash
dc up --build bean
```

* Ensure the seeds don't fail