### PR TITLE
basket: Add ease to builds and deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@
 # air live reload files
 !*/config/.air.toml
 
+# basket files
+!/basket/setup
+!/basket/build
+!/basket/compose
+
 # trellis files
 !/trellis/nginx.conf
 !/trellis/services.dev/*.conf

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ An honest day's work.
 
 ## Description
 
-A mono-repo for all things Go.
+A mono-repo of all the projects that make up the harvest.

--- a/basket/README.md
+++ b/basket/README.md
@@ -1,0 +1,43 @@
+# basket
+From farm to table.
+
+## Description
+
+Harvest's primitive deployment tool.
+
+## Dependencies
+
+### Local
+
+* Docker
+
+### Remote
+
+* Ubuntu Jammy 22.04 LTS x64
+
+## Setup
+
+1. Create a new Ubuntu Jammy 22.04 LTS x64 droplet on DigitalOcean.
+
+1. Add your SSH key to the droplet.
+
+1. Let basket do the setup for you.
+
+    ```bash
+    > basket/setup <droplet-ip>
+    ```
+
+## Guide
+
+### Build
+
+```bash
+> basket/build bean latest 1.0.0
+```
+
+### Deploy
+
+```bash
+> basket/compose pull <service>
+> basket/compose up -d --no-deps --force-recreate <service>
+```

--- a/basket/build
+++ b/basket/build
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+function main() {
+  service="$1"
+  shift
+
+  versions="$@"
+
+  trap "exit" INT
+
+  if ! valid_input $service $versions; then
+    echo "Usage: $0 <bean|trellis> <versions>"
+    echo "Example: $0 trellis 1.0.0 1 latest"
+    return 1
+  fi
+
+  if ! confirm_build $service $versions; then
+  echo "Aborted"
+    return 1
+  fi
+
+  init_build $service $versions
+}
+
+function valid_input() {
+  service=$1
+  shift
+
+  versions="$@"
+
+  case $service in
+    "bean" | "trellis")
+      return 0
+      ;;
+  esac
+
+  if [ -n "$versions" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+function confirm_build() {
+  service="$1"
+  shift
+
+  versions="$@"
+
+  tags=$(get_tags $service $versions)
+  echo "Building: "
+  printf "  - %s\n" ${tags//-t /}
+  echo ""
+
+  echo "Continue? (y/n)"
+  read confirm
+  if [[ $confirm =~ ^[Yy]$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+function init_build() {
+  service="$1"
+  shift
+
+  versions="$@"
+
+  tags=$(get_tags $service $versions)
+
+  docker buildx build \
+    --platform linux/amd64 \
+    -f $service/docker/Dockerfile.prod \
+    $tags \
+    --push \
+    .
+}
+
+function get_tags() {
+  service=$1
+  shift
+
+  versions="$@"
+
+  tags=""
+  for version in $versions; do
+    tags="$tags -t whatis277/$service:$version"
+  done
+
+  echo $tags
+}
+
+main "$@"

--- a/basket/build
+++ b/basket/build
@@ -15,7 +15,7 @@ function main() {
   fi
 
   if ! confirm_build $service $versions; then
-  echo "Aborted"
+    echo "Aborted"
     return 1
   fi
 

--- a/basket/compose
+++ b/basket/compose
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+function main() {
+  args="$@"
+
+  docker -c basket compose \
+    -f docker-compose.yml \
+    -f docker-compose.prod.yml \
+    $args
+}
+
+main "$@"

--- a/basket/setup
+++ b/basket/setup
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+function main() {
+  server=$1
+  if [ -z $server ]; then
+    echo "Usage: $0 <server-ip>"
+    return 1
+  fi
+
+  trap "exit" INT
+
+  ssh -o "StrictHostKeyChecking no" \
+    root@$server "$(typeset -f); setup_remote"
+
+  setup_local $server
+}
+
+function setup_remote() {
+  if id -u "basket" >/dev/null 2>&1; then
+    echo "Basket user is already setup"
+    return 0
+  fi
+
+  add_basket_user
+
+  setup_ports
+
+  setup_docker
+}
+
+function setup_local() {
+  server=$1
+
+  docker context create \
+    --docker "host=ssh://basket@$server" \
+    --description "Harvest production context" \
+    basket
+}
+
+function add_basket_user() {
+  adduser basket \
+    --gecos "" \
+    --disabled-password
+
+  passwd -d basket
+
+  usermod -aG sudo basket
+
+  rsync --archive --chown=basket:basket ~/.ssh /home/basket
+}
+
+function setup_ports() {
+  ufw allow OpenSSH
+  ufw allow http
+  ufw allow https
+
+  ufw --force enable
+}
+
+function setup_docker() {
+  # ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+  # ref: https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-22-04
+
+  apt update -y
+  apt install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+    https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+  apt update -y
+  apt install -y docker-ce
+
+  usermod -aG docker basket
+
+  systemctl enable docker
+  systemctl start docker
+}
+
+main $1

--- a/bean/README.md
+++ b/bean/README.md
@@ -14,7 +14,8 @@ A subscription tracker for the rest of us.
 
 ### Production
 
-TODO
+* Bean: https://whatisbean.com
+* SMTP: https://app.postmarkapp.com
 
 ### Documentation
 
@@ -67,6 +68,35 @@ There are other documentations under `<dir>/README.md` where relevant.
 
 ```bash
 > docker compose exec -e INTEGRATION=1 bean go test ./... -v
+```
+
+### Deploy
+
+#### Database
+
+On the first run, you need to create the user, database, and schema.
+
+```sql
+CREATE USER bean WITH PASSWORD 'secret-password';
+CREATE DATABASE bean;
+GRANT CONNECT ON DATABASE bean TO bean;
+
+\c bean
+CREATE SCHEMA bean AUTHORIZATION bean;
+GRANT ALL ON SCHEMA bean TO bean;
+```
+
+#### Server
+
+```bash
+> basket/compose pull bean
+> basket/compose up -d --no-deps --force-recreate bean
+```
+
+#### Migrations
+
+```bash
+> basket/compose exec bean tern migrate
 ```
 
 ## Testing

--- a/trellis/README.md
+++ b/trellis/README.md
@@ -5,10 +5,40 @@ Branching out.
 
 A router that connects harvest with the world.
 
-## Guide
+## Guides
 
 ### Run
 
 ```bash
 > docker compose up trellis
+```
+
+### Deploy
+
+#### SSL certificate
+
+##### First time deployment
+
+The first time you deploy trellis, you need to deploy certbot first.
+
+```bash
+> basket/compose pull certbot
+> basket/compose run --rm certbot
+```
+
+##### Renewal
+
+```bash
+> basket/compose run --rm certbot
+> basket/compose exec trellis nginx -s reload
+```
+
+#### NGINX
+
+Before you do this, make sure you set up the SSL certificates first.
+Otherwise, NGINX will fail to start.
+
+```bash
+> basket/compose pull trellis
+> basket/compose up -d --no-deps --force-recreate trellis
 ```


### PR DESCRIPTION
Basket is the equivalent to "farm to table"

You just pick up the harvest and go on your way

It helps:
* setup a new ubuntu server
* alias docker compose
* build and push images

The setup of a new server is annoying 
I know, from personal experience, I will blow things up eventually
So it's helpful to have a script to do things automatically

Aliasing docker compose ensures I never forget to specify which compose files to use

The building and pushing images helps ensure I also never forget to add important flags like `--platform`

Testing pre-requisites:
* Postgres 
* Redis 

Testing instructions:
1. Set up a new droplet on DigitalOcean

1. Point the domain to the droplet

1. Give the droplet a reserved IP address

1. Run basket setup

    ```bash
    > basket/setup <droplet-ip-addr>
    ```

1. Build and push current `bean` and `trellis` images

    ```bash
    > basket/build bean 1.0.0
    > basket/build trellis 1.0.0
    ```

1. Pull all service images

    ```bash
    > basket/compose pull certbot trellis bean
    ```

1. Generate SSL certificates manually

    ```bash
    > basket/compose run --rm certbot
    ```

1. Start all services 

    ```bash
    > basket/compose up -d bean trellis
    ```

1. Run the migrations on `bean`

    ```bash
    > basket/compose exec bean tern migrate
    ```

1. Ensure https://whatisbean.com is working fine