### PR TITLE
bean: Fix nil ref auth sessions

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -42,6 +42,11 @@ func (c *Controller) Authenticate(next base.HTTPHandler) base.HTTPHandler {
 			}
 		}
 
+		if session == nil {
+			UnauthedUserRedirect(w, r)
+			return nil
+		}
+
 		err = c.createSessionToken(w, sessionToken)
 		if err != nil {
 			UnauthedUserRedirect(w, r)
@@ -84,6 +89,11 @@ func (c *Controller) Authorize() base.HTTPHandler {
 					err,
 				),
 			}
+		}
+
+		if sessionToken == nil {
+			UnauthedUserRedirect(w, r)
+			return nil
 		}
 
 		err = c.createSessionToken(w, sessionToken)


### PR DESCRIPTION
After #179, we started returning nil sessions or session tokens.

However, we forgot to update the resolver to handle the nil reference. 

Testing instructions:
1. Run bean

```bash
dc up --build bean
```

1. Request a login link on http://whatisbean.local

1. Wait 10 minutes until the token expires 

1. Open the link

1. Ensure you're redirected back to the login page