### PR TITLE
bean: Fix cookie on safelinks redirect

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -251,7 +251,8 @@ func main() {
 
 	s.Route("GET /{$}", marketingController.LandingPage())
 
-	s.Route("GET /auth/{id}/{password}", authController.Authorize())
+	s.Route("GET /auth/{id}/{password}", authController.AuthorizeIntermediary("/x/auth"))
+	s.Route("GET /x/auth/{id}/{password}", authController.Authorize())
 
 	s.Route("GET /login", authController.LoginPage())
 	s.Route("POST /login", authController.LoginForm())

--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -111,3 +111,21 @@ func (c *Controller) Authorize() base.HTTPHandler {
 		return nil
 	}
 }
+
+func (c *Controller) AuthorizeIntermediary(authRoute string) base.HTTPHandler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		id, password := r.PathValue("id"), r.PathValue("password")
+		if id == "" || password == "" {
+			UnauthedUserRedirect(w, r)
+			return nil
+		}
+
+		http.Redirect(
+			w,
+			r,
+			fmt.Sprintf("%s/%s/%s", authRoute, id, password),
+			http.StatusSeeOther,
+		)
+		return nil
+	}
+}


### PR DESCRIPTION
Adds an intermediary `/auth` which redirects to `/x/auth`

This fixes a bug with Microsoft's SafeLinks when logging in

Microsoft would wrap the login URL with their safe link stuff
Then, the user would be redirected to `/auth`
There, the token would be consumed, but no session would get set

The intermediary redirects using 303 which forces a GET request to `/x/auth`
We also are on the same site, so we don't need to worry about SameSite stuff

However, I've kept `SameSite=Lax` just for better user experience

Testing instructions:
Sadly testing this locally is not worth the effort.
So on production...

1. Attempt to login with a Microsoft email at https://whatisbean.com/login

1. Ensure the link is wrapped with the safelinks stuff

1. Ensure you're logged in after clicking the link