### PR TITLE
bean: Fix safelinks consuming login token

### DIFF
--- a/bean/internal/adapter/controller/auth/auth.go
+++ b/bean/internal/adapter/controller/auth/auth.go
@@ -114,6 +114,10 @@ func (c *Controller) Authorize() base.HTTPHandler {
 
 func (c *Controller) AuthorizeIntermediary(authRoute string) base.HTTPHandler {
 	return func(w http.ResponseWriter, r *http.Request) error {
+		if r.Method == http.MethodHead {
+			return nil
+		}
+
 		id, password := r.PathValue("id"), r.PathValue("password")
 		if id == "" || password == "" {
 			UnauthedUserRedirect(w, r)


### PR DESCRIPTION
Okay, so #190 didn't fix it.
Anyway, instead of reverting it, we're going to repurpose it.

Thanks to the awesome folks on https://github.com/FusionAuth/fusionauth-issues/issues/629, it's all happening because of a HEAD request.
The one-time token is being consumed. 

In the thread, they mention that some clients use GET requests not HEAD.

But honestly:
* what are the chances I even get users on bean
* what are the chances the users of bean use those email clients

So 🤷🏼 

Testing instructions are similar to #190 