### PR TITLE
bean: Switch to new subscription model

### DIFF
--- a/bean/cmd/server/main.go
+++ b/bean/cmd/server/main.go
@@ -235,8 +235,7 @@ func main() {
 		AcceptTestEvents: env.BuyMeACoffee.AcceptTestEvents,
 		WebhookSecret:    env.BuyMeACoffee.WebhookSecret,
 
-		Passwordless: passwordlessAuth,
-		Memberships:  memberships,
+		Memberships: memberships,
 	}
 
 	s := server.New(&server.Config{

--- a/bean/internal/driver/buymeacoffee/buymeacoffee.go
+++ b/bean/internal/driver/buymeacoffee/buymeacoffee.go
@@ -11,10 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/whatis277/harvest/bean/internal/entity/model"
-
 	"github.com/whatis277/harvest/bean/internal/usecase/membership"
-	"github.com/whatis277/harvest/bean/internal/usecase/passwordless"
 
 	"github.com/whatis277/harvest/bean/internal/adapter/controller/base"
 )
@@ -23,8 +20,7 @@ type Controller struct {
 	AcceptTestEvents bool
 	WebhookSecret    string
 
-	Passwordless passwordless.UseCase
-	Memberships  membership.UseCase
+	Memberships membership.UseCase
 }
 
 func (c *Controller) Webhook() base.HTTPHandler {
@@ -152,32 +148,6 @@ func (c *Controller) membershipStarted(
 
 			Message: fmt.Sprintf(
 				"buymeacoffee: webhook: error creating membership: %v",
-				err,
-			),
-		}
-	}
-
-	err = c.Passwordless.Login(ctx, email)
-	switch err.(type) {
-	case nil:
-		break
-
-	case model.UserInputError:
-		return &base.HTTPError{
-			Status: http.StatusBadRequest,
-
-			Message: fmt.Sprintf(
-				"buymeacoffee: webhook: error logging in user: %v",
-				err,
-			),
-		}
-
-	default:
-		return &base.HTTPError{
-			Status: http.StatusInternalServerError,
-
-			Message: fmt.Sprintf(
-				"buymeacoffee: webhook: error logging in user: %v",
 				err,
 			),
 		}

--- a/bean/internal/driver/template/signup.html
+++ b/bean/internal/driver/template/signup.html
@@ -12,7 +12,7 @@
   <p>
     If you want to use <strong>bean</strong>, <a target="_blank" href="https://www.buymeacoffee.com/whatis277/membership">subscribe</a>.
     <br />
-    After you subscribe, we email you a login link.
+    After you subscribe, head over to the login page.
   </p>
   <p>
     You'll have at least one subscription to track.
@@ -21,12 +21,12 @@
 
 <div class="section">
   <p>
-    It's $2 per month. Cancel anytime.
+    It's $1 per month. Cancel anytime.
   </p>
   <p>
-    We refund your first month if you ask.
+    It's our way of verifying you're not a bot.
     <br />
-    You also have to win a coin flip.
+    We refund the first month if you win a coin flip.
   </p>
 </div>
 {{ end }}


### PR DESCRIPTION
Switches to a single subscription for all products.

The subscription will be used to verify members. 

It still creates the user on bean.
When this service is needed elsewhere, we can abstract it outside bean.

For now, that's not necessary.

No testing needed.