### PR TITLE
basket: Add docker script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@
 !/basket/setup
 !/basket/build
 !/basket/compose
+!/basket/docker
 
 # trellis files
 !/trellis/nginx.conf

--- a/basket/docker
+++ b/basket/docker
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function main() {
+  args="$@"
+
+  docker -c basket \
+    $args
+}
+
+main "$@"


### PR DESCRIPTION
Adds utility to call docker instead of doing `docker -c basket <something>` every time 🤦🏼 

Testing instructions:
1. ```bash
    basket/docker ps 
    ```

1. ```bash
    basket/docker images --digests
    ```